### PR TITLE
Fix C++ warnings in Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -75,9 +75,12 @@ build --copt=-Wno-tautological-compare
 build --copt=-Wno-unknown-pragmas
 build --copt=-Wimplicit-fallthrough
 build --copt=-Wno-unused-but-set-variable
+# Bazel's default C++ toolchain enables -Wunused-but-set-parameter; CMake does not.
+build --copt=-Wno-unused-but-set-parameter
 
 # --- GCC-specific warning flags (default compiler) ---
 # These are in an else() branch in configurecompiler.cmake (not Clang).
+# Silently ignored by Clang when -Wno-unknown-warning-option is set.
 build --copt=-Wno-uninitialized
 build --copt=-Wno-strict-aliasing
 build --copt=-Wno-array-bounds
@@ -87,26 +90,66 @@ build --cxxopt=-Wno-restrict
 build --copt=-Wno-stringop-truncation
 build --cxxopt=-Wno-class-memaccess
 
+# --- Clang-specific warning flags (configurecompiler.cmake) ---
+# IMPORTANT: These MUST be plain "build" lines (not "build:clang") because
+# "build --config=clang" on line 27 causes config expansion BEFORE the
+# plain "build" lines above.  If these were under "build:clang", they would
+# appear before -Wall, and -Wall would re-enable the warnings.
+# Unknown -Wno-* flags are silently ignored by GCC, so this is safe.
+build --copt=-Wno-unknown-warning-option
+build --copt=-ferror-limit=4096
+build --copt=-Wno-null-conversion
+build --copt=-Wno-unused-private-field
+build --copt=-Wno-constant-logical-operand
+build --copt=-Wno-pragma-pack
+build --copt=-Wno-incompatible-ms-struct
+build --copt=-Wno-reserved-identifier
+build --copt=-Wno-unsafe-buffer-usage
+build --copt=-Wno-single-bit-bitfield-constant-conversion
+build --copt=-Wno-cast-function-type-strict
+build --copt=-Wno-switch-default
+build --cxxopt=-Wno-nontrivial-memaccess
+
+# Exec/tool warning flags (for tools like ilasm built with cfg = "exec")
+build --host_copt=-Wall
+build --host_copt=-Wno-unused-variable
+build --host_copt=-Wno-unused-value
+build --host_copt=-Wno-unused-function
+build --host_copt=-Wno-tautological-compare
+build --host_copt=-Wno-unknown-pragmas
+build --host_copt=-Wimplicit-fallthrough
+build --host_copt=-Wno-unused-but-set-variable
+build --host_copt=-Wno-unused-but-set-parameter
+build --host_copt=-Wno-uninitialized
+build --host_copt=-Wno-strict-aliasing
+build --host_copt=-Wno-array-bounds
+build --host_cxxopt=-Wno-misleading-indentation
+build --host_cxxopt=-Wno-stringop-overflow
+build --host_cxxopt=-Wno-restrict
+build --host_copt=-Wno-stringop-truncation
+build --host_cxxopt=-Wno-class-memaccess
+build --host_copt=-Wno-unknown-warning-option
+build --host_copt=-ferror-limit=4096
+build --host_copt=-Wno-null-conversion
+build --host_copt=-Wno-unused-private-field
+build --host_copt=-Wno-constant-logical-operand
+build --host_copt=-Wno-pragma-pack
+build --host_copt=-Wno-incompatible-ms-struct
+build --host_copt=-Wno-reserved-identifier
+build --host_copt=-Wno-unsafe-buffer-usage
+build --host_copt=-Wno-single-bit-bitfield-constant-conversion
+build --host_copt=-Wno-cast-function-type-strict
+build --host_copt=-Wno-switch-default
+build --host_cxxopt=-Wno-nontrivial-memaccess
+
 # --- Clang compiler (config:clang) ---
 # Matches CMake default: uses clang/clang++ with lld linker.
+# NOTE: Only compiler/linker selection goes here. Warning flags MUST go
+# in plain "build" lines above to avoid config expansion ordering issues.
 build:clang --repo_env=CC=clang-18
 build:clang --repo_env=CXX=clang++-18
 build:clang --linkopt=-fuse-ld=lld
 build:clang --define compiler=clang
-# Undo GCC-specific flags (not recognized by Clang with -Werror)
-build:clang --copt=-Wno-unknown-warning-option
-build:clang --copt=-ferror-limit=4096
-# Clang-specific warnings from configurecompiler.cmake
-build:clang --copt=-Wno-unused-private-field
-build:clang --copt=-Wno-constant-logical-operand
-build:clang --copt=-Wno-pragma-pack
-build:clang --copt=-Wno-incompatible-ms-struct
-build:clang --copt=-Wno-reserved-identifier
-build:clang --copt=-Wno-unsafe-buffer-usage
-build:clang --copt=-Wno-single-bit-bitfield-constant-conversion
-build:clang --copt=-Wno-cast-function-type-strict
-build:clang --copt=-Wno-switch-default
-build:clang --cxxopt=-Wno-nontrivial-memaccess
 
 # Disable warnings that CMake also suppresses for vendored code
 build --per_file_copt=src/native/external/.*@-w
@@ -132,60 +175,32 @@ build --cpu=k8
 # CoreCLR and libraries have independent debug/release configurations,
 # matching MSBuild's -rc (runtime config) and -lc (libraries config).
 #
-# Mechanism: per_file_copt scopes C++ defines by source path.  The
-# //:clr_config and //:libs_config string_flag build settings control
-# which config_setting rules match in BUILD files (for select()).
-# .bazelrc --config sections bundle both the flag value and the
-# per_file_copt overrides.
+# Debug/checked/release defines are set per-target in BUILD files via
+# select() on //:clr_config and //:libs_config.  See CLR_CONFIG_DEFINES
+# in src/coreclr/coreclr_defs.bzl and NATIVE_CONFIG_DEFINES in
+# src/native/native_defs.bzl.  The --config flags below set the
+# string_flag values that drive those select() expressions.
 
-# --- CoreCLR debug defines (default) ---
-# Matches CMake Debug config for src/coreclr/**. build.sh defaults to
-# Debug, so the Bazel default must match.
+# --- CoreCLR default: debug ---
 build --//:clr_config=debug
-build --per_file_copt=src/coreclr/.*@-DDEBUG,-D_DEBUG,-D_DBG,-DBUILDENV_DEBUG=1,-DDISABLE_CONTRACTS,-DURTBLDENV_FRIENDLY=Debug,-DFEATURE_INTERPRETER,-DFEATURE_JAVAMARSHAL,-mcx16
 
-# NativeAOT has its own struct definitions (e.g. REGDISPLAY) that conflict
-# with coreclr's _DEBUG-conditional fields.  Strip debug defines for those
-# sources so the shared code (gcinfodecoder etc.) compiles correctly.
-build --per_file_copt=src/coreclr/nativeaot/.*@-UDEBUG,-U_DEBUG,-U_DBG,-UBUILDENV_DEBUG,-UFEATURE_INTERPRETER,-UFEATURE_JAVAMARSHAL
-
-# VM- and debug-specific debug defines (only for vm/debug/runtime paths)
-build --per_file_copt=src/coreclr/vm/.*,src/coreclr/debug/.*,src/coreclr/runtime/.*@-DFEATURE_CACHED_INTERFACE_DISPATCH
-# WRITE_BARRIER_CHECK is added via select() on the VM cee_wks_core target
-# (not per_file_copt) because GC sources compiled by VM have gc/ paths that
-# would also match standalone GC targets which must NOT have this define.
-
-# --- Libraries native debug defines (default) ---
-# Lighter set for src/native/libs/** and src/native/corehost/**.
+# --- Libraries default: debug ---
 build --//:libs_config=debug
-build --per_file_copt=src/native/libs/.*,src/native/corehost/.*@-DDEBUG,-D_DEBUG
 
 # =====================================================================
 # --config=clr_checked: Checked CoreCLR
 # =====================================================================
-# Like Debug but with release optimization (-O2).  Assertions and debug
-# defines remain, but BUILDENV_DEBUG→BUILDENV_CHECKED.
 build:clr_checked --//:clr_config=checked
-# Undo BUILDENV_DEBUG, set BUILDENV_CHECKED; undo URTBLDENV_FRIENDLY=Debug, set =Checked.
-# Add -O2 to override any default optimization level for coreclr sources.
-build:clr_checked --per_file_copt=src/coreclr/.*@-UBUILDENV_DEBUG,-DBUILDENV_CHECKED=1,-UURTBLDENV_FRIENDLY=Debug,-DURTBLDENV_FRIENDLY=Checked,-O2
 
 # =====================================================================
 # --config=clr_release: Release CoreCLR
 # =====================================================================
-# Undo all debug defines, set release defines.
 build:clr_release --//:clr_config=release
-# Undo debug defines, then set release values.
-build:clr_release --per_file_copt=src/coreclr/.*@-UDEBUG,-U_DEBUG,-U_DBG,-UBUILDENV_DEBUG,-UDISABLE_CONTRACTS,-UURTBLDENV_FRIENDLY=Debug,-UFEATURE_INTERPRETER,-UFEATURE_JAVAMARSHAL,-DNDEBUG,-DDISABLE_CONTRACTS,-DURTBLDENV_FRIENDLY=Retail
-# Also undo the VM/debug-specific debug defines.
-build:clr_release --per_file_copt=src/coreclr/vm/.*,src/coreclr/debug/.*,src/coreclr/runtime/.*@-UFEATURE_CACHED_INTERFACE_DISPATCH
 
 # =====================================================================
 # --config=libs_release: Release libraries
 # =====================================================================
 build:libs_release --//:libs_config=release
-# Undo debug defines, set release values for native libs and corehost.
-build:libs_release --per_file_copt=src/native/libs/.*,src/native/corehost/.*@-UDEBUG,-U_DEBUG,-DNDEBUG
 
 # =====================================================================
 # --config=release: Release everything (convenience)

--- a/src/coreclr/binder/BUILD.bazel
+++ b/src/coreclr/binder/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/binder/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -39,6 +39,7 @@ cc_library(
         "-Isrc/coreclr/binder",
         "-Isrc/coreclr/binder/inc",
     ] + CORECLR_COPTS,
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     deps = [
         "//src/coreclr/inc:coreclr_inc",

--- a/src/coreclr/classlibnative/BUILD.bazel
+++ b/src/coreclr/classlibnative/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -55,6 +55,7 @@ cc_library(
         "-Isrc/coreclr/classlibnative/bcltype",
         "-Isrc/coreclr/classlibnative/inc",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     alwayslink = True,
     deps = _CLN_DEPS,
@@ -71,6 +72,7 @@ cc_library(
     copts = _CLN_COPTS + [
         "-Isrc/coreclr/classlibnative/inc",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     alwayslink = True,
     deps = _CLN_DEPS,

--- a/src/coreclr/coreclr_defs.bzl
+++ b/src/coreclr/coreclr_defs.bzl
@@ -1,6 +1,7 @@
 # Shared constants for CoreCLR Bazel builds (linux-x64).
 # Import into BUILD.bazel files with:
 #   load("//src/coreclr:coreclr_defs.bzl", "CORECLR_DEFINES", "CORECLR_COPTS")
+#   load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CLR_CONFIG_COPTS")
 
 # --- Feature defines for linux-x64 retail ---
 # Derived from clrdefinitions.cmake and clrfeatures.cmake.
@@ -101,3 +102,70 @@ CORECLR_COPTS = [
     "-Isrc/native",
     "-Isrc/native/inc",
 ]
+
+# --- Debug/checked/release defines ---
+# Matches CMake's per-config compile_definitions from configurecompiler.cmake.
+#
+# CLR_BASE_CONFIG_DEFINES: base defines from configurecompiler.cmake (lines 60-62)
+#   that apply to ALL coreclr targets, including NativeAOT.
+#
+# CLR_CONFIG_DEFINES: full set including clrdefinitions.cmake additions
+#   (FEATURE_INTERPRETER, FEATURE_JAVAMARSHAL) that only apply to coreclr
+#   proper (not NativeAOT — CMake includes clrdefinitions.cmake AFTER
+#   add_subdirectory(nativeaot)).
+#
+# Standalone GC targets must NOT use either — they are always retail and get
+# their own defines via _GC_STANDALONE_DEFINES in gc/BUILD.bazel.
+
+_BASE_DEBUG = [
+    "DEBUG",
+    "_DEBUG",
+    "_DBG",
+    "DISABLE_CONTRACTS",
+]
+
+_BASE_RELEASE = [
+    "NDEBUG",
+    "DISABLE_CONTRACTS",
+]
+
+CLR_BASE_CONFIG_DEFINES = select({
+    "//:clr_debug": _BASE_DEBUG + [
+        "BUILDENV_DEBUG=1",
+        "URTBLDENV_FRIENDLY=Debug",
+    ],
+    "//:clr_checked": _BASE_DEBUG + [
+        "BUILDENV_CHECKED=1",
+        "URTBLDENV_FRIENDLY=Checked",
+    ],
+    "//:clr_release": _BASE_RELEASE + [
+        "URTBLDENV_FRIENDLY=Retail",
+    ],
+})
+
+CLR_CONFIG_DEFINES = select({
+    "//:clr_debug": _BASE_DEBUG + [
+        "BUILDENV_DEBUG=1",
+        "URTBLDENV_FRIENDLY=Debug",
+        "FEATURE_INTERPRETER",
+        "FEATURE_JAVAMARSHAL",
+    ],
+    "//:clr_checked": _BASE_DEBUG + [
+        "BUILDENV_CHECKED=1",
+        "URTBLDENV_FRIENDLY=Checked",
+        "FEATURE_INTERPRETER",
+        "FEATURE_JAVAMARSHAL",
+    ],
+    "//:clr_release": _BASE_RELEASE + [
+        "URTBLDENV_FRIENDLY=Retail",
+    ],
+})
+
+# --- Debug/checked/release copts ---
+# Flags that vary by config but aren't -D defines (e.g. optimization level).
+# Checked adds -O2; release is handled by Bazel's -c opt.
+CLR_CONFIG_COPTS = select({
+    "//:clr_debug": [],
+    "//:clr_checked": ["-O2"],
+    "//:clr_release": [],
+})

--- a/src/coreclr/debug/BUILD.bazel
+++ b/src/coreclr/debug/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/debug/*/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -51,6 +51,11 @@ cc_library(
     copts = CORECLR_COPTS + [
         "-Isrc/coreclr/debug/inc",
     ],
+    local_defines = CLR_CONFIG_DEFINES + select({
+        "//:clr_debug": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//:clr_checked": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//conditions:default": [],
+    }),
     defines = CORECLR_DEFINES + [
         "FEATURE_PERFTRACING_STANDALONE_PAL",
         "PAL_IMPLEMENTATION",
@@ -98,7 +103,16 @@ cc_library(
         "-Isrc/coreclr/debug",
     ] + CORECLR_COPTS + [
         "-DFEATURE_NO_HOST",
-    ],
+    ] + select({
+        "//:clr_debug": ["-mcx16"],
+        "//:clr_checked": ["-mcx16"],
+        "//conditions:default": [],
+    }),
+    local_defines = CLR_CONFIG_DEFINES + select({
+        "//:clr_debug": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//:clr_checked": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//conditions:default": [],
+    }),
     defines = CORECLR_DEFINES + [
         "FEATURE_VIRTUAL_STUB_DISPATCH",
     ],

--- a/src/coreclr/dlls/mscoree/coreclr/BUILD.bazel
+++ b/src/coreclr/dlls/mscoree/coreclr/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -27,6 +27,7 @@ cc_binary(
         "-include", "src/coreclr/vm/common.h",
         "-Wno-error",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES + [
         "FX_VER_INTERNALNAME_STR=CoreCLR.dll",
         "FEATURE_VIRTUAL_STUB_DISPATCH",

--- a/src/coreclr/dlls/mscorpe/BUILD.bazel
+++ b/src/coreclr/dlls/mscorpe/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/dlls/mscorpe/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -23,6 +23,7 @@ cc_library(
         "-Isrc/coreclr/md/inc",
         "-include", "src/coreclr/dlls/mscorpe/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES + [
         "FEATURE_CORECLR",
     ],

--- a/src/coreclr/dlls/mscorrc/BUILD.bazel
+++ b/src/coreclr/dlls/mscorrc/BUILD.bazel
@@ -5,7 +5,7 @@
 # by processrc.sh. We use a pre-generated .cpp for Bazel builds.
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -15,6 +15,7 @@ cc_library(
     name = "mscorrc",
     srcs = ["bazel/mscorrc.cpp"],
     copts = CORECLR_COPTS,
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     alwayslink = True,
     deps = [

--- a/src/coreclr/gc/BUILD.bazel
+++ b/src/coreclr/gc/BUILD.bazel
@@ -96,7 +96,7 @@ cc_library(
     copts = _GC_COPTS + [
         "-Isrc/coreclr/gc/unix",
     ],
-    defines = _GC_STANDALONE_DEFINES,
+    local_defines = _GC_STANDALONE_DEFINES,
     alwayslink = True,
     deps = [
         ":gc_headers",
@@ -132,7 +132,7 @@ cc_library(
         "-mavx2",
         "-Wno-unused-but-set-parameter",
     ],
-    defines = _GC_STANDALONE_DEFINES,
+    local_defines = _GC_STANDALONE_DEFINES,
     alwayslink = True,
     deps = [
         ":gc_headers",

--- a/src/coreclr/gcinfo/BUILD.bazel
+++ b/src/coreclr/gcinfo/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/gcinfo/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -47,6 +47,7 @@ cc_library(
     srcs = _GCINFO_ALLARCH_SOURCES,
     hdrs = glob(["*.h"]),
     copts = CORECLR_COPTS,
+    local_defines = CLR_CONFIG_DEFINES,
     includes = ["."],
     alwayslink = True,
     deps = ["//src/coreclr/inc:coreclr_inc"],

--- a/src/coreclr/ilasm/BUILD.bazel
+++ b/src/coreclr/ilasm/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/ilasm/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 # grammar_before.cpp / grammar_after.cpp are #included by prebuilt/asmparse.cpp
 # (bison-generated parser) — they must be available but not compiled separately.
@@ -38,6 +38,7 @@ cc_binary(
         "-Wno-array-bounds",
         "-Wno-unused-label",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES + [
         "__ILASM__",
         "_FEATURE_NO_HOST",

--- a/src/coreclr/inc/BUILD.bazel
+++ b/src/coreclr/inc/BUILD.bazel
@@ -2,7 +2,7 @@
 # Nearly all coreclr components depend on this.
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -58,6 +58,7 @@ cc_library(
         "//src/coreclr/pal:prebuilt/idl/xcordebug_i.cpp",
     ],
     copts = CORECLR_COPTS + ["-D_MIDL_USE_GUIDDEF_"],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     alwayslink = True,
     deps = [":coreclr_inc"],

--- a/src/coreclr/interop/BUILD.bazel
+++ b/src/coreclr/interop/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/interop/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -22,6 +22,7 @@ cc_library(
     copts = CORECLR_COPTS + [
         "-Isrc/coreclr/interop/inc",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     includes = [
         ".",
         "inc",

--- a/src/coreclr/jit/BUILD.bazel
+++ b/src/coreclr/jit/BUILD.bazel
@@ -3,7 +3,7 @@
 # Matches CMake: src/coreclr/jit/CMakeLists.txt + jit/static/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -208,6 +208,8 @@ _JIT_COPTS = [
     "-Wno-endif-labels",
     "-Wno-changes-meaning",
     "-Wno-sizeof-pointer-div",
+    # emitarm64.h uses static_assert without message (C++17) in a C++11 build.
+    "-Wno-c++17-extensions",
 ]
 
 _JIT_DEFINES_BASE = [
@@ -229,6 +231,7 @@ cc_library(
     srcs = _JIT_COMMON_SOURCES + _JIT_AMD64_SOURCES,
     textual_hdrs = ["smcommon.cpp"],
     copts = _JIT_COPTS,
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES + _JIT_DEFINES_BASE + _JIT_SIMD_DEFINES,
     deps = [
         "//src/coreclr/inc:coreclr_inc",

--- a/src/coreclr/md/BUILD.bazel
+++ b/src/coreclr/md/BUILD.bazel
@@ -1,7 +1,7 @@
 # CoreCLR metadata headers and libraries.
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -66,6 +66,7 @@ cc_library(
         "-Isrc/coreclr/md/compiler",
         "-include", "src/coreclr/md/compiler/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = _MD_DEFINES,
     alwayslink = True,
     deps = ["//src/coreclr/inc:coreclr_inc"],
@@ -100,6 +101,7 @@ cc_library(
         "-Isrc/coreclr/md/compiler",
         "-include", "src/coreclr/md/compiler/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = _MD_DEFINES + [
         "FEATURE_METADATA_EMIT_PORTABLE_PDB",
     ],
@@ -127,6 +129,7 @@ cc_library(
         "-Isrc/coreclr/md/runtime",
         "-include", "src/coreclr/md/runtime/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = _MD_DEFINES + [
         "NO_COR",
     ],
@@ -154,6 +157,7 @@ cc_library(
         "-Isrc/coreclr/md/runtime",
         "-include", "src/coreclr/md/runtime/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = _MD_DEFINES + [
         "NO_COR",
         "FEATURE_METADATA_EMIT_PORTABLE_PDB",
@@ -183,6 +187,7 @@ cc_library(
         "-Isrc/coreclr/md/enc",
         "-include", "src/coreclr/md/enc/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = _MD_DEFINES,
     alwayslink = True,
     deps = ["//src/coreclr/inc:coreclr_inc"],
@@ -209,6 +214,7 @@ cc_library(
         "-Isrc/coreclr/md/enc",
         "-include", "src/coreclr/md/enc/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = _MD_DEFINES + [
         "FEATURE_METADATA_EMIT_PORTABLE_PDB",
     ],

--- a/src/coreclr/md/ceefilegen/BUILD.bazel
+++ b/src/coreclr/md/ceefilegen/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/md/ceefilegen/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -21,6 +21,7 @@ cc_library(
         "-Isrc/coreclr/md/inc",
         "-include", "src/coreclr/md/ceefilegen/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     alwayslink = True,
     deps = ["//src/coreclr/inc:coreclr_inc"],

--- a/src/coreclr/nativeaot/BUILD.bazel
+++ b/src/coreclr/nativeaot/BUILD.bazel
@@ -3,6 +3,7 @@
 #                src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_BASE_CONFIG_DEFINES")
 load("//src/coreclr/nativeaot:nativeaot_defs.bzl", "NATIVEAOT_COPTS", "NATIVEAOT_DEFINES")
 
 package(default_visibility = ["//visibility:public"])
@@ -300,6 +301,7 @@ cc_library(
     textual_hdrs = _GC_TEXTUAL_HDRS + _TEXTUAL_CPP_INCLUDES,
     copts = NATIVEAOT_COPTS + _GENDIR_COPTS + _GC_UNIX_COPTS + _EVENTING_COPTS,
     defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = _RUNTIME_DEPS,
 )
@@ -319,6 +321,7 @@ cc_library(
     textual_hdrs = _GC_TEXTUAL_HDRS + _TEXTUAL_CPP_INCLUDES,
     copts = NATIVEAOT_COPTS + _GENDIR_COPTS + _GC_UNIX_COPTS + _EVENTING_COPTS + _LLVM_LIBUNWIND_COPTS,
     defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = _RUNTIME_DEPS + [
         ":eventpipe_disabled",
@@ -336,6 +339,7 @@ cc_library(
     textual_hdrs = _GC_TEXTUAL_HDRS + _TEXTUAL_CPP_INCLUDES,
     copts = NATIVEAOT_COPTS + _GENDIR_COPTS + _GC_UNIX_COPTS + _EVENTING_COPTS + _LLVM_LIBUNWIND_COPTS,
     defines = NATIVEAOT_DEFINES + ["FEATURE_SVR_GC"],
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = _RUNTIME_DEPS + [
         ":eventpipe_disabled",
@@ -353,6 +357,7 @@ cc_library(
     textual_hdrs = _GC_TEXTUAL_HDRS + _TEXTUAL_CPP_INCLUDES,
     copts = NATIVEAOT_COPTS + _GENDIR_COPTS + _GC_UNIX_COPTS + _EVENTING_COPTS,
     defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = _RUNTIME_DEPS,
 )
@@ -364,6 +369,7 @@ cc_library(
     textual_hdrs = _GC_TEXTUAL_HDRS + _TEXTUAL_CPP_INCLUDES,
     copts = NATIVEAOT_COPTS + _GENDIR_COPTS + _GC_UNIX_COPTS + _EVENTING_COPTS,
     defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = _RUNTIME_DEPS,
 )
@@ -393,6 +399,7 @@ cc_library(
         "-mavx2",
     ],
     defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = [
         "//src/coreclr/gc:gc_headers",
@@ -407,6 +414,7 @@ cc_library(
         "-Isrc/coreclr/gc/vxsort",
     ],
     defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = [
         "//src/coreclr/gc:gc_headers",
@@ -422,6 +430,7 @@ cc_library(
     srcs = ["Bootstrap/main.cpp"],
     copts = NATIVEAOT_COPTS,
     defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = ["//src/native/minipal"],
 )
@@ -431,6 +440,7 @@ cc_library(
     srcs = ["Bootstrap/main.cpp"],
     copts = NATIVEAOT_COPTS,
     defines = NATIVEAOT_DEFINES + ["NATIVEAOT_DLL"],
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
     deps = ["//src/native/minipal"],
 )
@@ -440,6 +450,7 @@ cc_library(
     srcs = ["Bootstrap/stdcppshim.cpp"],
     copts = NATIVEAOT_COPTS,
     defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
     linkstatic = True,
 )
 

--- a/src/coreclr/nativeresources/BUILD.bazel
+++ b/src/coreclr/nativeresources/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/nativeresources/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -11,6 +11,7 @@ cc_library(
     srcs = ["resourcestring.cpp"],
     hdrs = ["resourcestring.h"],
     copts = CORECLR_COPTS,
+    local_defines = CLR_CONFIG_DEFINES,
     includes = ["."],
     alwayslink = True,
     deps = ["//src/coreclr/inc:coreclr_inc"],

--- a/src/coreclr/pal/BUILD.bazel
+++ b/src/coreclr/pal/BUILD.bazel
@@ -3,7 +3,7 @@
 # and global include_directories in src/coreclr/CMakeLists.txt (for headers).
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -290,6 +290,7 @@ cc_library(
     copts = CORECLR_COPTS + [
         "-Isrc/coreclr/pal/src/include",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     alwayslink = True,
     linkstatic = True,

--- a/src/coreclr/unwinder/BUILD.bazel
+++ b/src/coreclr/unwinder/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/unwinder/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -32,6 +32,7 @@ cc_library(
         "-Isrc/coreclr/debug/daccess",
         "-Isrc/coreclr/interop/inc",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     includes = ["."],
     alwayslink = True,
     deps = ["//src/coreclr/inc:coreclr_inc"],

--- a/src/coreclr/utilcode/BUILD.bazel
+++ b/src/coreclr/utilcode/BUILD.bazel
@@ -3,7 +3,7 @@
 # Matches CMake: src/coreclr/utilcode/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -81,6 +81,7 @@ cc_library(
         # Replicate CMake's target_precompile_headers(utilcode PRIVATE [["stdafx.h"]])
         "-include", "src/coreclr/utilcode/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     alwayslink = True,
     deps = [
@@ -100,6 +101,7 @@ cc_library(
         "-Isrc/coreclr/utilcode",
         "-include", "src/coreclr/utilcode/stdafx.h",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES + [
         "SELF_NO_HOST",
     ],

--- a/src/coreclr/vm/BUILD.bazel
+++ b/src/coreclr/vm/BUILD.bazel
@@ -83,6 +83,11 @@ cc_library(
         "-Isrc/coreclr/vm/amd64",
         "-Isrc/coreclr",
     ] + CORECLR_COPTS,
+    local_defines = CLR_CONFIG_DEFINES + select({
+        "//:clr_debug": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//:clr_checked": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//conditions:default": [],
+    }),
     defines = _VM_DEFINES,
     linkstatic = True,
     deps = [

--- a/src/coreclr/vm/BUILD.bazel
+++ b/src/coreclr/vm/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/vm/CMakeLists.txt + vm/wks/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -326,7 +326,16 @@ cc_library(
         "//src/coreclr/gc:gcee.cpp",
         "//src/coreclr/System.Private.CoreLib:src/System/Runtime/ExceptionServices/AsmOffsets.cs",
     ],
-    copts = _VM_COPTS,
+    copts = _VM_COPTS + select({
+        "//:clr_debug": ["-mcx16"],
+        "//:clr_checked": ["-mcx16"],
+        "//conditions:default": [],
+    }),
+    local_defines = CLR_CONFIG_DEFINES + select({
+        "//:clr_debug": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//:clr_checked": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//conditions:default": [],
+    }),
     defines = _VM_DEFINES + ["GC_DESCRIPTOR"] + select({
         "//:debug_mode": ["WRITE_BARRIER_CHECK"],
         "//conditions:default": [],
@@ -357,7 +366,16 @@ cc_library(
         "codeman.cpp",
         "peimagelayout.cpp",
     ],
-    copts = _VM_COPTS,
+    copts = _VM_COPTS + select({
+        "//:clr_debug": ["-mcx16"],
+        "//:clr_checked": ["-mcx16"],
+        "//conditions:default": [],
+    }),
+    local_defines = CLR_CONFIG_DEFINES + select({
+        "//:clr_debug": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//:clr_checked": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//conditions:default": [],
+    }),
     defines = _VM_DEFINES,
     alwayslink = True,
     deps = [

--- a/src/coreclr/vm/eventing/BUILD.bazel
+++ b/src/coreclr/vm/eventing/BUILD.bazel
@@ -5,7 +5,7 @@
 # Currently uses pre-generated files; a Bazel genrule can replace this later.
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//src/coreclr:coreclr_defs.bzl", "CORECLR_COPTS", "CORECLR_DEFINES")
+load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])
 
@@ -48,6 +48,7 @@ cc_library(
         "-include", "src/coreclr/vm/common.h",
         "-Wno-error",
     ],
+    local_defines = CLR_CONFIG_DEFINES,
     defines = CORECLR_DEFINES,
     alwayslink = True,
     deps = [
@@ -130,6 +131,7 @@ cc_library(
         "//src/native/eventpipe:dn-diagnosticserver-pal-srcs",
     ],
     copts = _EP_COPTS,
+    local_defines = CLR_CONFIG_DEFINES,
     defines = _EP_DEFINES,
     alwayslink = True,
     linkstatic = True,

--- a/src/native/corehost/BUILD.bazel
+++ b/src/native/corehost/BUILD.bazel
@@ -3,6 +3,7 @@
 #           nethost (shared+static).
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_shared_library")
+load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 package(default_visibility = ["//src/native/corehost:__subpackages__"])
 
@@ -104,6 +105,7 @@ cc_library(
         "-Isrc/native/corehost/hostmisc",
     ],
     defines = COREHOST_DEFINES,
+    local_defines = NATIVE_CONFIG_DEFINES,
     linkopts = [
         "-ldl",
         "-lpthread",
@@ -128,6 +130,7 @@ cc_library(
         "-Isrc/native/corehost/hostmisc",
     ],
     defines = COREHOST_DEFINES,
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = [":hostmisc"],
 )
 
@@ -162,6 +165,7 @@ cc_library(
         "-Isrc/native/corehost/hostmisc",
     ],
     defines = COREHOST_DEFINES + ["EXPORT_SHARED_API"],
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = [
         ":hostmisc",
         "//src/native/external/rapidjson",
@@ -210,6 +214,7 @@ cc_library(
         "-Isrc/native/corehost/hostmisc",
     ],
     defines = COREHOST_DEFINES + ["EXPORT_SHARED_API"],
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = [":hostcommon"],
 )
 
@@ -269,6 +274,7 @@ cc_library(
         "-Isrc/native/corehost/hostpolicy",
     ],
     defines = COREHOST_DEFINES + ["EXPORT_SHARED_API"],
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = [":hostcommon"],
 )
 
@@ -302,6 +308,7 @@ cc_binary(
         "-Isrc/native/corehost/apphost",
     ],
     defines = COREHOST_DEFINES,
+    local_defines = NATIVE_CONFIG_DEFINES,
     linkopts = ["-Wl,-Bsymbolic"],
     visibility = ["//visibility:public"],
     deps = [
@@ -328,6 +335,7 @@ cc_binary(
         "-Isrc/native/corehost/apphost",
     ],
     defines = COREHOST_DEFINES + ["FEATURE_APPHOST"],
+    local_defines = NATIVE_CONFIG_DEFINES,
     linkopts = ["-Wl,-Bsymbolic"],
     visibility = ["//visibility:public"],
     deps = [
@@ -352,6 +360,7 @@ cc_library(
         "FEATURE_LIBHOST",
         "NETHOST_EXPORT",
     ],
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = [
         ":fxr_resolver",
         ":hostmisc",

--- a/src/native/corehost/test/BUILD.bazel
+++ b/src/native/corehost/test/BUILD.bazel
@@ -2,6 +2,7 @@
 # Cross-platform tests only; Windows-only tests (comsxs, ijw, typelibs) are excluded.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_shared_library", "cc_test")
+load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 COREHOST_TEST_COPTS = [
     "-Isrc/native/corehost",
@@ -27,6 +28,7 @@ cc_test(
     srcs = ["fx_ver/test_fx_ver.cpp"],
     copts = COREHOST_TEST_COPTS,
     defines = COREHOST_TEST_DEFINES,
+    local_defines = NATIVE_CONFIG_DEFINES,
     linkstatic = True,
     deps = [
         "//src/native/corehost:hostcommon",
@@ -45,6 +47,7 @@ cc_library(
     ],
     copts = COREHOST_TEST_COPTS,
     defines = COREHOST_TEST_DEFINES + ["EXPORT_SHARED_API"],
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = ["//src/native/corehost:hostmisc"],
 )
 
@@ -68,6 +71,7 @@ cc_library(
         "MOCKHOSTFXR_2_2",
         "EXPORT_SHARED_API",
     ],
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = [
         "//src/native/corehost:hostcommon",
         "//src/native/corehost:nethost_lib",
@@ -91,6 +95,7 @@ cc_library(
         "MOCKHOSTFXR_5_0",
         "EXPORT_SHARED_API",
     ],
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = [
         "//src/native/corehost:hostcommon",
         "//src/native/corehost:nethost_lib",
@@ -111,6 +116,7 @@ cc_library(
     srcs = ["mockhostpolicy/mockhostpolicy.cpp"],
     copts = COREHOST_TEST_COPTS,
     defines = COREHOST_TEST_DEFINES + ["EXPORT_SHARED_API"],
+    local_defines = NATIVE_CONFIG_DEFINES,
     deps = ["//src/native/corehost:hostmisc"],
 )
 
@@ -145,6 +151,7 @@ cc_binary(
         "-Isrc/native/corehost/nethost",
     ],
     defines = COREHOST_TEST_DEFINES,
+    local_defines = NATIVE_CONFIG_DEFINES,
     linkopts = [
         "-lpthread",
         "-Wl,-rpath,$$ORIGIN",

--- a/src/native/libs/System.Globalization.Native/BUILD.bazel
+++ b/src/native/libs/System.Globalization.Native/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.Globalization.Native for linux-x64
 # Produces libSystem.Globalization.Native.so (shared) and libSystem.Globalization.Native.a (static)
@@ -39,6 +40,7 @@ cc_library(
         "-Isrc/native/libs/System.Globalization.Native/bazel/linux-glibc-x64",
     ],
     linkopts = ["-ldl"],
+    local_defines = NATIVE_CONFIG_DEFINES,
     visibility = ["//visibility:public"],
     deps = [
         "//src/native/libs:common",

--- a/src/native/libs/System.IO.Compression.Native/BUILD.bazel
+++ b/src/native/libs/System.IO.Compression.Native/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.IO.Compression.Native for linux-x64
 # Produces libSystem.IO.Compression.Native.so (shared)
@@ -17,6 +18,7 @@ cc_library(
         "-Isrc/native/libs/bazel",
     ],
     defines = ["BROTLI_SHARED_COMPILATION"],
+    local_defines = NATIVE_CONFIG_DEFINES,
     visibility = ["//visibility:public"],
     deps = [
         "//src/native/external/brotli:brotlidec",

--- a/src/native/libs/System.IO.Ports.Native/BUILD.bazel
+++ b/src/native/libs/System.IO.Ports.Native/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.IO.Ports.Native for linux-x64
 # Produces libSystem.IO.Ports.Native.so (shared) and libSystem.IO.Ports.Native.a (static)
@@ -16,6 +17,7 @@ cc_library(
         "-Isrc/native/libs/bazel",
         "-Isrc/native/libs/System.IO.Ports.Native",
     ],
+    local_defines = NATIVE_CONFIG_DEFINES,
     visibility = ["//visibility:public"],
     deps = [
         "//src/native/libs:common",

--- a/src/native/libs/System.Native/BUILD.bazel
+++ b/src/native/libs/System.Native/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 cc_library(
     name = "System.Native_lib",
@@ -41,6 +42,7 @@ cc_library(
     defines = [
         "HAS_CONSOLE_SIGNALS",
     ],
+    local_defines = NATIVE_CONFIG_DEFINES,
     linkopts = ["-lrt"],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/native/libs/System.Net.Security.Native/BUILD.bazel
+++ b/src/native/libs/System.Net.Security.Native/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.Net.Security.Native for linux-x64
 # Produces libSystem.Net.Security.Native.so (shared) and libSystem.Net.Security.Native.a (static)
@@ -19,6 +20,7 @@ cc_library(
     defines = [
         "GSS_SHIM",
     ],
+    local_defines = NATIVE_CONFIG_DEFINES,
     linkopts = ["-ldl"],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/native/libs/System.Security.Cryptography.Native/BUILD.bazel
+++ b/src/native/libs/System.Security.Cryptography.Native/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.Security.Cryptography.Native.OpenSsl for linux-x64
 # Produces libSystem.Security.Cryptography.Native.OpenSsl.so (shared)
@@ -62,6 +63,7 @@ cc_library(
         "OPENSSL_API_COMPAT=0x10100000L",
         "FEATURE_DISTRO_AGNOSTIC_SSL",
     ],
+    local_defines = NATIVE_CONFIG_DEFINES,
     linkopts = [
         "-ldl",
         "-pthread",

--- a/src/native/native_defs.bzl
+++ b/src/native/native_defs.bzl
@@ -1,0 +1,18 @@
+# Shared native library definitions for debug/release configuration.
+#
+# Usage in BUILD files:
+#   load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
+#   cc_library(
+#       ...
+#       local_defines = NATIVE_CONFIG_DEFINES,
+#   )
+
+NATIVE_CONFIG_DEFINES = select({
+    "//:libs_debug": [
+        "DEBUG",
+        "_DEBUG",
+    ],
+    "//:libs_release": [
+        "NDEBUG",
+    ],
+})


### PR DESCRIPTION
- Add -Wno-unused-but-set-parameter globally (Bazel toolchain enables it; CMake does not)
- Add -Wno-null-conversion for clang (matches configurecompiler.cmake:30)
- Add -Wno-macro-redefined for clang (suppresses per_file_copt redefinition artifacts)
- Change gc_pal and gc_vxsort from defines to local_defines to prevent standalone GC defines (NDEBUG, BUILD_AS_STANDALONE, VERIFY_HEAP, etc.) from leaking to dependent targets like libcoreclr.so