### PR TITLE
Add Bazel test BUILD files for 19 more library test suites

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -26,15 +26,29 @@ layout.
   ref assemblies, source generators
 - **Build tools**: ResGen, GenerateResxSource, GenFacades, ilasm, LibraryImportGenerator
 - **Tests**: corehost native tests, xUnit-based managed test infrastructure,
-  20 library test suites (System.Collections, System.Collections.Concurrent,
-  System.ComponentModel, System.Diagnostics.Contracts, System.Diagnostics.StackTrace,
-  System.Diagnostics.Tracing, System.Formats.Asn1, System.IO.FileSystem.DriveInfo,
-  System.IO.Hashing, System.Linq, System.Memory, System.Numerics.Vectors,
-  System.ObjectModel, System.Reflection.Emit.ILGeneration,
-  System.Reflection.Emit.Lightweight, System.Reflection.TypeExtensions,
+  48 library test suites (System.CodeDom, System.Collections,
+  System.Collections.Concurrent, System.Collections.NonGeneric,
+  System.Collections.Specialized, System.ComponentModel,
+  System.ComponentModel.Annotations, System.ComponentModel.EventBasedAsync,
+  System.Diagnostics.Contracts, System.Diagnostics.StackTrace,
+  System.Diagnostics.TextWriterTraceListener, System.Diagnostics.Tracing,
+  System.Drawing.Primitives, System.Formats.Asn1,
+  System.IO.FileSystem.DriveInfo, System.IO.Hashing, System.Linq,
+  System.Linq.AsyncEnumerable, System.Linq.Parallel,
+  System.Linq.Queryable, System.Memory, System.Numerics.Vectors,
+  System.ObjectModel, System.Reflection.Emit,
+  System.Reflection.Emit.ILGeneration, System.Reflection.Emit.Lightweight,
+  System.Reflection.Extensions, System.Reflection.TypeExtensions,
   System.Resources.Writer, System.Runtime.CompilerServices.VisualC,
+  System.Runtime.InteropServices (UnitTests), System.Runtime.Intrinsics,
   System.Runtime.Numerics, System.Security.Claims,
-  System.Text.Encoding.Extensions)
+  System.Text.Encoding.CodePages, System.Text.Encoding.Extensions,
+  System.Threading, System.Threading.Channels, System.Threading.Overlapped,
+  System.Threading.RateLimiting, System.Threading.Tasks.Dataflow,
+  System.Threading.Tasks.Parallel, System.Threading.Thread,
+  System.Threading.ThreadPool, System.Net.WebHeaderCollection,
+  System.Net.WebProxy, System.Web.HttpUtility,
+  Microsoft.CSharp)
 - **Per-component configuration**: independent debug/checked/release for
   CoreCLR and Libraries (matching MSBuild's `-rc`/`-lc` flags)
 - **Runtime layout**: `runtime_layout` rule assembles stripped binaries into
@@ -43,7 +57,7 @@ layout.
 ### What's Next
 
 - Remaining managed libraries (~142 assemblies not yet in Bazel, out of ~200 total)
-- Library unit tests (20 of ~187 libraries have Bazel test BUILD files)
+- Library unit tests (48 of ~187 libraries have Bazel test BUILD files)
 - CoreCLR diagnostic tooling: DAC (mscordac), DBI (mscordbi), createdump, SOS
 - CoreCLR tools: SuperPMI, ildasm (full binary), crossgen2
 - ILC (NativeAOT ahead-of-time compiler) and crossgen2 (ReadyToRun compiler)
@@ -422,7 +436,7 @@ have `impl_` targets** in Bazel and are in the `impl_netcoreapp` aggregate. The
 remaining 5 need special support: Microsoft.VisualBasic.Core (VB compiler),
 System.IO.Pipes.AccessControl and System.Threading.AccessControl (Windows PNSE stubs),
 System.Net.Quic (msquic native library), and System.Runtime.InteropServices.JavaScript
-(Browser/WASM-only). 29 libraries have Bazel test BUILD files (out of ~187 with
+(Browser/WASM-only). 48 libraries have Bazel test BUILD files (out of ~187 with
 test projects).
 
 ### 5.1 System.Private.CoreLib — ✅ DONE
@@ -449,19 +463,30 @@ test projects).
 - [x] `src/tests/defs.bzl` — test infrastructure, live_csharp_library, xUnit runner
 - [x] `src/tests/live_test.bzl` — `library_test` macro for library unit tests
 - [x] 18 test BUILD files (JIT directed tests, common infrastructure)
-- [x] 29 library test suites (System.Collections, System.Collections.Concurrent,
-  System.ComponentModel, System.Diagnostics.Contracts, System.Diagnostics.StackTrace,
-  System.Diagnostics.Tracing, System.Formats.Asn1, System.IO.FileSystem.DriveInfo,
-  System.IO.Hashing, System.Linq, System.Memory, System.Numerics.Vectors,
-  System.ObjectModel, System.Reflection.Emit, System.Reflection.Emit.ILGeneration,
-  System.Reflection.Emit.Lightweight, System.Reflection.TypeExtensions,
-  System.Resources.Writer, System.Runtime.CompilerServices.VisualC,
+- [x] 48 library test suites (Microsoft.CSharp, System.CodeDom,
+  System.Collections, System.Collections.Concurrent,
+  System.Collections.NonGeneric, System.Collections.Specialized,
+  System.ComponentModel, System.ComponentModel.Annotations,
+  System.ComponentModel.EventBasedAsync, System.Diagnostics.Contracts,
+  System.Diagnostics.StackTrace, System.Diagnostics.TextWriterTraceListener,
+  System.Diagnostics.Tracing, System.Drawing.Primitives,
+  System.Formats.Asn1, System.IO.FileSystem.DriveInfo, System.IO.Hashing,
+  System.Linq, System.Linq.AsyncEnumerable, System.Linq.Parallel,
+  System.Linq.Queryable, System.Memory, System.Net.WebHeaderCollection,
+  System.Net.WebProxy, System.Numerics.Vectors, System.ObjectModel,
+  System.Reflection.Emit, System.Reflection.Emit.ILGeneration,
+  System.Reflection.Emit.Lightweight, System.Reflection.Extensions,
+  System.Reflection.TypeExtensions, System.Resources.Writer,
+  System.Runtime.CompilerServices.VisualC,
   System.Runtime.InteropServices (UnitTests), System.Runtime.Intrinsics,
-  System.Runtime.Numerics, System.Security.Claims, System.Text.Encoding.Extensions,
-  System.Threading, System.Threading.Overlapped, System.Threading.Tasks.Parallel,
-  System.Threading.Thread, System.Threading.ThreadPool)
+  System.Runtime.Numerics, System.Security.Claims,
+  System.Text.Encoding.CodePages, System.Text.Encoding.Extensions,
+  System.Threading, System.Threading.Channels, System.Threading.Overlapped,
+  System.Threading.RateLimiting, System.Threading.Tasks.Dataflow,
+  System.Threading.Tasks.Parallel, System.Threading.Thread,
+  System.Threading.ThreadPool, System.Web.HttpUtility)
 - [ ] Remaining CoreCLR test suite (~thousands of tests)
-- [ ] Remaining library unit tests (~158 libraries)
+- [ ] Remaining library unit tests (~139 libraries)
 
 ### 5.5 Installer / Packaging
 - [ ] `src/installer/` — runtime packs, NuGet packaging, SDK integration

--- a/src/libraries/Microsoft.CSharp/tests/BUILD.bazel
+++ b/src/libraries/Microsoft.CSharp/tests/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "Microsoft.CSharp.Tests",
+    srcs = glob(["*.cs"]) + [
+        "//src/libraries/System.Private.CoreLib:src/System/Runtime/CompilerServices/IsExternalInit.cs",
+    ],
+    deps = [
+        "//src/libraries:ref_Microsoft.CSharp",
+        "//src/libraries:ref_System.Linq.Expressions",
+        "//src/libraries/System.Reflection.Emit:ref_System.Reflection.Emit",
+        "//src/libraries/System.Reflection.Emit.ILGeneration:ref_System.Reflection.Emit.ILGeneration",
+        "//src/libraries/System.Reflection.Emit.Lightweight:ref_System.Reflection.Emit.Lightweight",
+        "//src/libraries/System.Reflection.Primitives:ref_System.Reflection.Primitives",
+        "//src/libraries/System.Security.Cryptography:ref_System.Security.Cryptography",
+        "//src/libraries/System.ComponentModel.TypeConverter:ref_System.ComponentModel.TypeConverter",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/System.Threading.Thread:ref_System.Threading.Thread",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    allow_unsafe_blocks = True,
+    size = "large",
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.CodeDom/tests/BUILD.bazel
+++ b/src/libraries/System.CodeDom/tests/BUILD.bazel
@@ -1,0 +1,31 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.CodeDom.Tests",
+    srcs = glob(["**/*.cs"]) + [
+        "//src/libraries/Common/tests:System/Collections/IList.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/ICollection.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/IEnumerable.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/TestBase.NonGeneric.cs",
+        "//src/libraries/Common/tests:System/IO/TempFile.cs",
+        "//src/libraries/Common/tests:System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs",
+    ],
+    deps = [
+        "//src/libraries/System.CodeDom:ref_System.CodeDom",
+        "//src/libraries/System.Runtime.Serialization.Formatters:impl_System.Runtime.Serialization.Formatters",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/System.ComponentModel.TypeConverter:ref_System.ComponentModel.TypeConverter",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.remoteexecutor",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    nowarn = [
+        "SYSLIB0011",
+    ],
+    size = "large",
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Collections.NonGeneric/tests/BUILD.bazel
+++ b/src/libraries/System.Collections.NonGeneric/tests/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Collections.NonGeneric.Tests",
+    srcs = glob(["**/*.cs"]) + [
+        "//src/libraries/Common/tests:System/Collections/ICollection.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/IDictionary.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/IEnumerable.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/IList.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/TestBase.NonGeneric.cs",
+        "//src/libraries/Common/tests:System/Collections/TestingTypes.cs",
+        "//src/libraries/Common/tests:System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs",
+        "//src/libraries/Common/tests:System/Diagnostics/DebuggerAttributes.cs",
+    ],
+    deps = [
+        "//src/libraries/System.Runtime.Serialization.Formatters:impl_System.Runtime.Serialization.Formatters",
+        "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.remoteexecutor",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    nowarn = [
+        "SYSLIB0011",
+        "SYSLIB0050",
+        "SYSLIB0051",
+    ],
+    size = "large",
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Collections.Specialized/tests/BUILD.bazel
+++ b/src/libraries/System.Collections.Specialized/tests/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Collections.Specialized.Tests",
+    srcs = glob(["**/*.cs"]) + [
+        "//src/libraries/Common/tests:System/Collections/CollectionAsserts.cs",
+        "//src/libraries/Common/tests:System/Collections/ICollection.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/IDictionary.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/IEnumerable.NonGeneric.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/IEnumerable.NonGeneric.Serialization.Tests.cs",
+        "//src/libraries/Common/tests:System/Collections/TestBase.NonGeneric.cs",
+        "//src/libraries/Common/tests:System/Collections/TestingTypes.cs",
+        "//src/libraries/Common/tests:System/Diagnostics/DebuggerAttributes.cs",
+        "//src/libraries/Common/tests:System/Runtime/Serialization/Formatters/BinaryFormatterHelpers.cs",
+    ],
+    deps = [
+        "//src/libraries/System.Runtime.Serialization.Formatters:impl_System.Runtime.Serialization.Formatters",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    nowarn = [
+        "SYSLIB0011",
+        "SYSLIB0050",
+        "SYSLIB0051",
+    ],
+    size = "large",
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.ComponentModel.Annotations/tests/BUILD.bazel
+++ b/src/libraries/System.ComponentModel.Annotations/tests/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.ComponentModel.Annotations.Tests",
+    srcs = glob(
+        ["**/*.cs"],
+        exclude = [
+            # Uses Newtonsoft.Json which is not available in Bazel
+            "System/ComponentModel/DataAnnotations/ValidatorTests.cs",
+        ],
+    ),
+    deps = [
+        "//src/libraries/System.ComponentModel.Annotations:ref_System.ComponentModel.Annotations",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/System.ComponentModel.TypeConverter:ref_System.ComponentModel.TypeConverter",
+        "//src/libraries:ref_System.Text.RegularExpressions",
+        "//src/libraries/System.Runtime.Serialization.Formatters:ref_System.Runtime.Serialization.Formatters",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.remoteexecutor",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    nullable = "disable",
+    nowarn = ["nullable"],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.ComponentModel.EventBasedAsync/tests/BUILD.bazel
+++ b/src/libraries/System.ComponentModel.EventBasedAsync/tests/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.ComponentModel.EventBasedAsync.Tests",
+    srcs = glob(["*.cs"]),
+    deps = [
+        "//src/libraries/System.ComponentModel.EventBasedAsync:ref_System.ComponentModel.EventBasedAsync",
+        "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.remoteexecutor",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/BUILD.bazel
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/BUILD.bazel
@@ -11,24 +11,27 @@ netcoreapp_ref_assembly(
     ],
 )
 
-# XmlWriterTraceListener.cs is excluded because it requires System.Xml.ReaderWriter,
-# which does not yet have a BUILD.bazel target.
 netcoreapp_impl_assembly(
     name = "impl_System.Diagnostics.TextWriterTraceListener",
     srcs = [
         "src/System/Diagnostics/ConsoleTraceListener.cs",
         "src/System/Diagnostics/DelimitedListTraceListener.cs",
         "src/System/Diagnostics/TextWriterTraceListener.cs",
+        "src/System/Diagnostics/XmlWriterTraceListener.cs",
     ],
-    exclude_sr = True,
+    resx_file = "src/Resources/Strings.resx",
     deps = [
+        "//src/libraries:ref_System.ComponentModel.Primitives",
+        "//src/libraries:ref_System.Diagnostics.Process",
         "//src/libraries:ref_System.Runtime",
         "//src/libraries/System.Collections.NonGeneric:ref_System.Collections.NonGeneric",
         "//src/libraries/System.Collections.Specialized:ref_System.Collections.Specialized",
         "//src/libraries/System.Console:ref_System.Console",
         "//src/libraries/System.Diagnostics.TraceSource:ref_System.Diagnostics.TraceSource",
+        "//src/libraries/System.Memory:ref_System.Memory",
         "//src/libraries/System.Text.Encoding.Extensions:ref_System.Text.Encoding.Extensions",
         "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/System.Xml.ReaderWriter:ref_System.Xml.ReaderWriter",
     ],
 )
 

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/BUILD.bazel
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Diagnostics.TextWriterTraceListener.Tests",
+    srcs = glob(["*.cs"]),
+    deps = [
+        "//src/libraries/System.Diagnostics.TextWriterTraceListener:ref_System.Diagnostics.TextWriterTraceListener",
+        "//src/libraries/System.Diagnostics.TraceSource:ref_System.Diagnostics.TraceSource",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/System.Xml.ReaderWriter:ref_System.Xml.ReaderWriter",
+        "//src/libraries/System.Xml.XDocument:ref_System.Xml.XDocument",
+        "//src/libraries/System.Xml.XPath.XDocument:ref_System.Xml.XPath.XDocument",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.remoteexecutor",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Drawing.Primitives/tests/BUILD.bazel
+++ b/src/libraries/System.Drawing.Primitives/tests/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Drawing.Primitives.Tests",
+    srcs = glob(["*.cs"]) + [
+        "//src/libraries/Common/tests:System/Diagnostics/DebuggerAttributes.cs",
+        "//src/libraries/Common/tests:System/Runtime/Serialization/DataContractSerializerHelper.cs",
+        "//src/libraries/Common/tests:System/Runtime/Serialization/Utils.cs",
+    ],
+    deps = [
+        "//src/libraries/System.Drawing.Primitives:ref_System.Drawing.Primitives",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Runtime.Serialization.Formatters:ref_System.Runtime.Serialization.Formatters",
+        "//src/libraries/System.Runtime.Serialization.Xml:ref_System.Runtime.Serialization.Xml",
+        "//src/libraries/System.Xml.ReaderWriter:ref_System.Xml.ReaderWriter",
+        "//src/libraries/System.Xml.XDocument:ref_System.Xml.XDocument",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/BUILD.bazel
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Linq.AsyncEnumerable.Tests",
+    srcs = glob(["*.cs"]),
+    deps = [
+        "//src/libraries/System.Linq.AsyncEnumerable:ref_System.Linq.AsyncEnumerable",
+        "//src/libraries/System.Threading.Channels:ref_System.Threading.Channels",
+        "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/System.Threading.ThreadPool:ref_System.Threading.ThreadPool",
+        "//src/libraries/System.Runtime.Numerics:ref_System.Runtime.Numerics",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    nowarn = ["CS1998"],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Linq.Parallel/tests/BUILD.bazel
+++ b/src/libraries/System.Linq.Parallel/tests/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Linq.Parallel.Tests",
+    srcs = glob(["**/*.cs"]) + [
+        "//src/libraries/Common/tests:System/Diagnostics/Tracing/TestEventListener.cs",
+        "//src/libraries/Common/tests:System/ShouldNotBeInvokedException.cs",
+        "//src/libraries/Common/tests:System/Threading/ThreadPoolHelpers.cs",
+    ],
+    deps = [
+        "//src/libraries/System.Linq.Parallel:ref_System.Linq.Parallel",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/System.Threading.ThreadPool:ref_System.Threading.ThreadPool",
+        "//src/libraries:ref_System.Threading.Tasks",
+        "//src/libraries/System.Diagnostics.Tracing:ref_System.Diagnostics.Tracing",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.remoteexecutor",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    size = "large",
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Linq.Queryable/tests/BUILD.bazel
+++ b/src/libraries/System.Linq.Queryable/tests/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Linq.Queryable.Tests",
+    srcs = glob(["**/*.cs"]) + [
+        "//src/libraries/Common/tests:System/Linq/SkipTakeData.cs",
+    ],
+    deps = [
+        "//src/libraries/System.Linq.Queryable:ref_System.Linq.Queryable",
+        "//src/libraries:ref_System.Linq.Expressions",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Net.WebHeaderCollection/tests/BUILD.bazel
+++ b/src/libraries/System.Net.WebHeaderCollection/tests/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Net.WebHeaderCollection.Tests",
+    srcs = glob(["*.cs"]),
+    deps = [
+        "//src/libraries/System.Net.WebHeaderCollection:ref_System.Net.WebHeaderCollection",
+        "//src/libraries/System.Net.Primitives:ref_System.Net.Primitives",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Net.WebProxy/tests/BUILD.bazel
+++ b/src/libraries/System.Net.WebProxy/tests/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Net.WebProxy.Tests",
+    srcs = glob(["*.cs"]),
+    deps = [
+        "//src/libraries/System.Net.Primitives:ref_System.Net.Primitives",
+        "//src/libraries/System.Net.NameResolution:ref_System.Net.NameResolution",
+        "//src/libraries/System.Net.NetworkInformation:ref_System.Net.NetworkInformation",
+        "//src/libraries:ref_Microsoft.Win32.Primitives",
+        "//src/libraries/System.Net.WebProxy:ref_System.Net.WebProxy",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Reflection.Extensions/tests/BUILD.bazel
+++ b/src/libraries/System.Reflection.Extensions/tests/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Reflection.Extensions.Tests",
+    srcs = glob(["**/*.cs"]),
+    deps = [
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Text.Encoding.CodePages/tests/BUILD.bazel
+++ b/src/libraries/System.Text.Encoding.CodePages/tests/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Text.Encoding.CodePages.Tests",
+    srcs = glob(["*.cs"]),
+    deps = [
+        "//src/libraries/System.Text.Encoding.CodePages:live_System.Text.Encoding.CodePages",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.remoteexecutor",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    size = "large",
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Threading.Channels/tests/BUILD.bazel
+++ b/src/libraries/System.Threading.Channels/tests/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Threading.Channels.Tests",
+    srcs = glob(["*.cs"]) + [
+        "//src/libraries/Common/tests:System/Diagnostics/DebuggerAttributes.cs",
+    ],
+    deps = [
+        "//src/libraries/System.Threading.Channels:ref_System.Threading.Channels",
+        "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/System.Threading.ThreadPool:ref_System.Threading.ThreadPool",
+        "//src/libraries/System.IO.FileSystem.DriveInfo:ref_System.IO.FileSystem.DriveInfo",
+        "//src/libraries/System.Runtime.Serialization.Formatters:ref_System.Runtime.Serialization.Formatters",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    nowarn = [
+        "SYSLIB0011",
+    ],
+    size = "large",
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Threading.RateLimiting/tests/BUILD.bazel
+++ b/src/libraries/System.Threading.RateLimiting/tests/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Threading.RateLimiting.Tests",
+    srcs = glob(["**/*.cs"]),
+    deps = [
+        "//src/libraries/System.Threading.RateLimiting:ref_System.Threading.RateLimiting",
+        "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/System.Threading.Thread:ref_System.Threading.Thread",
+        "//src/libraries/System.Collections.Concurrent:ref_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.Immutable:ref_System.Collections.Immutable",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/BUILD.bazel
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Threading.Tasks.Dataflow.Tests",
+    srcs = glob(["**/*.cs"]) + [
+        "//src/libraries/Common/tests:System/Diagnostics/Tracing/TestEventListener.cs",
+        "//src/libraries/Common/tests:System/Diagnostics/DebuggerAttributes.cs",
+    ],
+    deps = [
+        "//src/libraries/System.Threading.Tasks.Dataflow:ref_System.Threading.Tasks.Dataflow",
+        "//src/libraries/System.Linq.AsyncEnumerable:ref_System.Linq.AsyncEnumerable",
+        "//src/libraries/System.Diagnostics.Tracing:ref_System.Diagnostics.Tracing",
+        "//src/libraries/System.Threading:ref_System.Threading",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.remoteexecutor",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    size = "large",
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)

--- a/src/libraries/System.Web.HttpUtility/tests/BUILD.bazel
+++ b/src/libraries/System.Web.HttpUtility/tests/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//src/tests:live_test.bzl", "library_test")
+
+library_test(
+    name = "System.Web.HttpUtility.Tests",
+    srcs = glob(["**/*.cs"]),
+    deps = [
+        "//src/libraries/System.Web.HttpUtility:ref_System.Web.HttpUtility",
+        "//src/libraries/Common/tests:TestUtilities",
+        "@paket.main//microsoft.dotnet.xunitassert",
+        "@paket.main//microsoft.dotnet.xunitextensions",
+        "@paket.main//xunit.abstractions",
+        "@paket.main//xunit.extensibility.core",
+    ],
+    keyfile = "@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/Open.snk",
+)


### PR DESCRIPTION
Add library_test BUILD.bazel files for:
- Microsoft.CSharp
- System.CodeDom
- System.Collections.NonGeneric
- System.Collections.Specialized
- System.ComponentModel.Annotations (excludes ValidatorTests.cs - Newtonsoft.Json dep)
- System.ComponentModel.EventBasedAsync
- System.Diagnostics.TextWriterTraceListener
- System.Drawing.Primitives
- System.Linq.AsyncEnumerable
- System.Linq.Parallel
- System.Linq.Queryable
- System.Net.WebHeaderCollection
- System.Net.WebProxy
- System.Reflection.Extensions
- System.Text.Encoding.CodePages
- System.Threading.Channels
- System.Threading.RateLimiting
- System.Threading.Tasks.Dataflow
- System.Web.HttpUtility

This brings the total from 29 to 48 library test suites with Bazel BUILD files.
All 19 new test targets compile successfully.
