### PR TITLE
Split PLATFORM_DEFINES into cc_defs.bzl to isolate C++ from C# cache

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -220,7 +220,7 @@
   "moduleExtensions": {
     "//paket:paket.main_extension.bzl%main_extension": {
       "general": {
-        "bzlTransitiveDigest": "4sMaXPOy7NkrtBcAfKMWmpEQ0E0omehvN7MlaD9mmqU=",
+        "bzlTransitiveDigest": "wmTIX8zUD8RPqI4c+Hwc4UrWXD+jDQ19KT/F4yZ5DCY=",
         "usagesDigest": "/++DsNDsPEafh99irUtCwOTCNp57HApeC8MUxM9rbUo=",
         "recordedInputs": [
           "REPO_MAPPING:,rules_dotnet rules_dotnet+",

--- a/cc_defs.bzl
+++ b/cc_defs.bzl
@@ -1,0 +1,39 @@
+# Platform defines matching CMake configurecompiler.cmake.
+# Used by native cc_library targets via local_defines = PLATFORM_DEFINES.
+#
+# This file is intentionally kept free of @rules_dotnet loads so that
+# changes to the C# tooling / rules_dotnet version don't invalidate the
+# Bazel analysis cache for C++ targets.
+PLATFORM_DEFINES = [
+    # configurecompiler.cmake — unconditional on Unix
+    "DISABLE_CONTRACTS",
+] + select({
+    "@platforms//os:macos": [
+        "HOST_64BIT",
+        "HOST_ARM64",
+        "HOST_UNIX",
+        "HOST_APPLE",
+        "HOST_OSX",
+        "TARGET_64BIT",
+        "TARGET_ARM64",
+        "TARGET_UNIX",
+        "TARGET_APPLE",
+        "TARGET_OSX",
+        # configurecompiler.cmake — macOS platform defines
+        "_XOPEN_SOURCE",
+        "_DARWIN_C_SOURCE",
+        "__DARWIN_NON_CANCELABLE=1",
+        # src/native/libs/CMakeLists.txt — macOS networking
+        "__APPLE_USE_RFC_3542",
+    ],
+    "@platforms//os:linux": [
+        "_GNU_SOURCE",
+        "HOST_64BIT",
+        "HOST_AMD64",
+        "HOST_UNIX",
+        "TARGET_64BIT",
+        "TARGET_AMD64",
+        "TARGET_UNIX",
+        "TARGET_LINUX",
+    ],
+})

--- a/defs.bzl
+++ b/defs.bzl
@@ -17,12 +17,6 @@ _ASSEMBLY_VERSION = _MAJOR_VERSION + "." + _MINOR_VERSION + ".0.0"
 _FILE_VERSION = "42.42.42.42424"
 _INFORMATIONAL_VERSION = PRODUCT_VERSION + "-dev"
 
-def from_coreclr_artifacts(file):
-    return select({
-        "@platforms//os:linux": [ Label("//:artifacts/bin/coreclr/linux.x64.Debug/%s" % file) ],
-        "@platforms//os:macos": [ Label("//:artifacts/bin/coreclr/osx.arm64.Debug/%s" % file) ],
-    })
-
 def _gen_resx_source_impl(ctx):
     resource_name = ctx.attr.resource_name if ctx.attr.resource_name else ("FxResources.%s.SR" % ctx.attr.assembly_name)
     ctx.actions.run(

--- a/defs.bzl
+++ b/defs.bzl
@@ -9,41 +9,6 @@ NETCOREAPP_TOOL_CURRENT = "net10.0"
 
 # Label for the Roslyn compiler server persistent worker binary.
 _SHARED_COMPILATION_WORKER = "@rules_dotnet//dotnet/private/tools/compiler_worker"
-# Platform defines matching CMake configurecompiler.cmake.
-# Used by native cc_library targets via local_defines = PLATFORM_DEFINES.
-PLATFORM_DEFINES = [
-    # configurecompiler.cmake — unconditional on Unix
-    "DISABLE_CONTRACTS",
-] + select({
-    "@platforms//os:macos": [
-        "HOST_64BIT",
-        "HOST_ARM64",
-        "HOST_UNIX",
-        "HOST_APPLE",
-        "HOST_OSX",
-        "TARGET_64BIT",
-        "TARGET_ARM64",
-        "TARGET_UNIX",
-        "TARGET_APPLE",
-        "TARGET_OSX",
-        # configurecompiler.cmake — macOS platform defines
-        "_XOPEN_SOURCE",
-        "_DARWIN_C_SOURCE",
-        "__DARWIN_NON_CANCELABLE=1",
-        # src/native/libs/CMakeLists.txt — macOS networking
-        "__APPLE_USE_RFC_3542",
-    ],
-    "@platforms//os:linux": [
-        "_GNU_SOURCE",
-        "HOST_64BIT",
-        "HOST_AMD64",
-        "HOST_UNIX",
-        "TARGET_64BIT",
-        "TARGET_AMD64",
-        "TARGET_UNIX",
-        "TARGET_LINUX",
-    ],
-})
 
 # Version constants matching eng/Versions.props
 _MAJOR_VERSION = PRODUCT_VERSION.split(".")[0]

--- a/src/coreclr/gcinfo/BUILD.bazel
+++ b/src/coreclr/gcinfo/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/gcinfo/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CLR_CONFIG_COPTS")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])

--- a/src/coreclr/pal/BUILD.bazel
+++ b/src/coreclr/pal/BUILD.bazel
@@ -3,7 +3,7 @@
 # and global include_directories in src/coreclr/CMakeLists.txt (for headers).
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_DEFINES", "CORECLR_COPTS", "CLR_CONFIG_COPTS", "CORECLR_DEFINES")
 
 package(default_visibility = ["//src/coreclr:__subpackages__"])

--- a/src/coreclr/tools/aot/jitinterface/BUILD.bazel
+++ b/src/coreclr/tools/aot/jitinterface/BUILD.bazel
@@ -2,7 +2,7 @@
 # Matches CMake: src/coreclr/tools/aot/jitinterface/CMakeLists.txt
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/native/corehost/BUILD.bazel
+++ b/src/native/corehost/BUILD.bazel
@@ -5,7 +5,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_shared_library")
 load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 
 package(default_visibility = ["//src/native/corehost:__subpackages__"])
 

--- a/src/native/libs/System.Globalization.Native/BUILD.bazel
+++ b/src/native/libs/System.Globalization.Native/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library", "objc_library")
 load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_COPTS")
 load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 
 # System.Globalization.Native for linux-x64
 # Produces libSystem.Globalization.Native.so (shared) and libSystem.Globalization.Native.a (static)

--- a/src/native/libs/System.IO.Compression.Native/BUILD.bazel
+++ b/src/native/libs/System.IO.Compression.Native/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.IO.Compression.Native for linux-x64

--- a/src/native/libs/System.IO.Ports.Native/BUILD.bazel
+++ b/src/native/libs/System.IO.Ports.Native/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.IO.Ports.Native for linux-x64

--- a/src/native/libs/System.Native/BUILD.bazel
+++ b/src/native/libs/System.Native/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 cc_library(

--- a/src/native/libs/System.Net.Security.Native/BUILD.bazel
+++ b/src/native/libs/System.Net.Security.Native/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.Net.Security.Native for linux-x64

--- a/src/native/libs/System.Security.Cryptography.Native/BUILD.bazel
+++ b/src/native/libs/System.Security.Cryptography.Native/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 load("//src/native:native_defs.bzl", "NATIVE_CONFIG_DEFINES")
 
 # System.Security.Cryptography.Native.OpenSsl for linux-x64

--- a/src/native/minipal/BUILD.bazel
+++ b/src/native/minipal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//:defs.bzl", "PLATFORM_DEFINES")
+load("//:cc_defs.bzl", "PLATFORM_DEFINES")
 load("//src/coreclr:coreclr_defs.bzl", "CLR_CONFIG_COPTS")
 
 exports_files(


### PR DESCRIPTION
All C++ BUILD files loaded PLATFORM_DEFINES from //:defs.bzl, which also imports from @rules_dotnet. Any change to C# build settings (shared compilation, rules_dotnet version bumps, etc.) caused defs.bzl's transitive .bzl digest to change, invalidating Bazel's analysis cache for every C++ target and causing widespread remote cache misses.

Extract PLATFORM_DEFINES into a new cc_defs.bzl that has no @rules_dotnet dependency, so C++ and C# build graphs are independent.