### PR TITLE
Fix Bazel library build warnings to match MSBuild

### DIFF
--- a/src/libraries/Microsoft.CSharp/BUILD.bazel
+++ b/src/libraries/Microsoft.CSharp/BUILD.bazel
@@ -192,6 +192,7 @@ netcoreapp_impl_assembly(
     defines = [
         "LEGACY_GETRESOURCESTRING_USER",
     ],
+    nowarn = ["nullable"],
 )
 
 ref_impl_pair(

--- a/src/libraries/System.Data.Common/BUILD.bazel
+++ b/src/libraries/System.Data.Common/BUILD.bazel
@@ -44,7 +44,7 @@ netcoreapp_impl_assembly(
     ],
     resx_file = "src/Resources/Strings.resx",
     allow_unsafe_blocks = True,
-    nowarn = ["SYSLIB0038"],
+    nowarn = ["SYSLIB0038", "CS8604"],
     deps = [
         "//src/libraries:ref_System.Private.CoreLib",
         "//src/libraries:impl_System.Runtime",

--- a/src/libraries/System.IO.FileSystem.AccessControl/BUILD.bazel
+++ b/src/libraries/System.IO.FileSystem.AccessControl/BUILD.bazel
@@ -22,5 +22,6 @@ netcoreapp_impl_assembly(
         "//src/libraries:ref_System.Runtime",
         "//src/libraries/System.Security.AccessControl:ref_System.Security.AccessControl",
         "//src/libraries/System.Security.Principal.Windows:ref_System.Security.Principal.Windows",
-    ]
+    ],
+    nullable = "annotations",
 )

--- a/src/libraries/System.Linq.Expressions/BUILD.bazel
+++ b/src/libraries/System.Linq.Expressions/BUILD.bazel
@@ -13,6 +13,7 @@ netcoreapp_ref_assembly(
         "//src/libraries:ref_System.Runtime",
         "//src/libraries/System.ObjectModel:ref_System.ObjectModel",
     ],
+    nowarn = ["CS0618"],
 )
 
 netcoreapp_impl_assembly(

--- a/src/libraries/System.Reflection.Metadata/BUILD.bazel
+++ b/src/libraries/System.Reflection.Metadata/BUILD.bazel
@@ -40,6 +40,7 @@ netcoreapp_impl_assembly(
     ],
     resx_file = "src/Resources/Strings.resx",
     allow_unsafe_blocks = True,
+    cls_compliant = False,
     defines = ["SYSTEM_REFLECTION_METADATA"],
     deps = [
         "//src/libraries/System.Collections:ref_System.Collections",

--- a/src/libraries/System.Security.AccessControl/BUILD.bazel
+++ b/src/libraries/System.Security.AccessControl/BUILD.bazel
@@ -23,4 +23,5 @@ netcoreapp_impl_assembly(
         "//src/libraries/System.Security.Principal.Windows:ref_System.Security.Principal.Windows",
     ],
     resx_file = "src/Resources/Strings.resx",
+    nullable = "annotations",
 )

--- a/src/libraries/System.Text.Encodings.Web/BUILD.bazel
+++ b/src/libraries/System.Text.Encodings.Web/BUILD.bazel
@@ -57,6 +57,7 @@ netcoreapp_impl_assembly(
         "//src/libraries/System.Threading:impl_System.Threading",
     ],
     resx_file = "src/Resources/Strings.resx",
+    nowarn = ["CS3011"],
     generate_facades = True,
     facade_contract_assembly = ":ref_System.Text.Encodings.Web",
 )

--- a/src/libraries/System.Threading.Tasks.Dataflow/BUILD.bazel
+++ b/src/libraries/System.Threading.Tasks.Dataflow/BUILD.bazel
@@ -72,6 +72,7 @@ netcoreapp_impl_assembly(
     generate_facades = True,
     facade_contract_assembly = ":ref_System.Threading.Tasks.Dataflow",
     resx_file = "src/Resources/Strings.resx",
+    nowarn = ["CS1589"],
 )
 
 ref_impl_pair(

--- a/src/libraries/defs.bzl
+++ b/src/libraries/defs.bzl
@@ -327,13 +327,24 @@ ref_impl_pair = rule(
 def live_csharp_library(
     name,
     deps = [],
+    nullable = "enable",
+    compiler_options = [],
     **kwargs
 ):
     deps = deps + LIVE_REFPACK_DEPS
 
+    # Match MSBuild compiler options for features (nullable/strict)
+    compiler_options = compiler_options + [
+        "/features:strict",
+        "/features:nullablePublicOnly",
+    ]
+
     csharp_library(
         name = name,
         deps = deps,
+        nullable = nullable,
+        langversion = "preview",
+        compiler_options = compiler_options,
         disable_implicit_framework_refs = True,
         target_frameworks = [ NETCOREAPP_CURRENT ],
         **kwargs


### PR DESCRIPTION
- Update live_csharp_library to set nullable=enable, langversion=preview, and /features:strict|nullablePublicOnly (matching netcoreapp_impl_assembly)
- Add per-library nowarn/cls_compliant to match MSBuild csproj settings:
  - Microsoft.CSharp: nowarn=nullable (suppresses CS8600-CS8767)
  - System.Reflection.Metadata: cls_compliant=False (suppresses CS3xxx)
  - System.Text.Encodings.Web: nowarn=CS3011
  - System.Linq.Expressions ref: nowarn=CS0618
  - System.Threading.Tasks.Dataflow: nowarn=CS1589 (XML doc include)
  - System.Data.Common: nowarn=CS8604 (ref assembly annotation diff)
- Set nullable=annotations for PNSE stub assemblies (AccessControl)