### PR TITLE
Shrink the set of assemblies need for Core_Root

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -132,6 +132,7 @@ copy_to_directory(
     }) + select({
         "@platforms//os:linux": [
             "//src/coreclr/System.Private.CoreLib:crossgen_System.Private.CoreLib",
+            "//src/native/libs/System.Security.Cryptography.Native:System.Security.Cryptography.Native.OpenSsl",
         ],
         "@platforms//os:macos": [],
     }),

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -113,33 +113,28 @@ runtime_layout(
     }),
 )
 
-# ── Core_Root: full test runtime ─────────────────────────────────────
+# ── Core_Root: minimal runtime for JIT/coreclr tests ─────────────────
+# Uses impl_netcoreapp_minimal (~30 assemblies) instead of impl_netcoreapp
+# (~145 assemblies). This reduces cache invalidation: changes to libraries
+# like System.Net.Sockets, System.Xml, etc. won't invalidate JIT test cache.
+# Library tests use shared_testhost which references impl_netcoreapp directly.
 copy_to_directory(
     name = "Core_Root",
     out = "Core_Root",
     srcs = [
         "//src/coreclr/hosts:corerun",
-        "//src/native/corehost:hostpolicy",
         "//src/native/libs/System.Native:System.Native",
         "//src/native/libs/System.Globalization.Native:System.Globalization.Native",
-        "//src/native/libs/System.IO.Compression.Native:System.IO.Compression.Native",
-        "//src/native/libs/System.IO.Ports.Native:System.IO.Ports.Native",
-        "//src/native/libs/System.Net.Security.Native:System.Net.Security.Native",
-        "//src/libraries:impl_netcoreapp",
+        "//src/libraries:impl_netcoreapp_minimal",
     ] + select({
         "@platforms//os:macos": ["//src/coreclr/dlls/mscoree/coreclr:libcoreclr_dylib"],
         "//conditions:default": ["//src/coreclr/dlls/mscoree/coreclr:libcoreclr.so"],
     }) + select({
         "@platforms//os:linux": [
             "//src/coreclr/System.Private.CoreLib:crossgen_System.Private.CoreLib",
-            "//src/native/libs/System.Security.Cryptography.Native:System.Security.Cryptography.Native.OpenSsl",
         ],
-        # macOS: skip OpenSSL (not available on macOS)
-        # Skip R2R crossgen on macOS for now (R2R segfaults at runtime, needs investigation)
-        # The IL CoreLib from impl_netcoreapp is used directly.
         "@platforms//os:macos": [],
     }),
-    # The R2R CoreLib (listed last) overwrites the IL version from impl_netcoreapp.
     allow_overwrites = True,
     replace_prefixes = {
         "System.Private.CoreLib.r2r.dll": "System.Private.CoreLib.dll",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -220,7 +220,7 @@
   "moduleExtensions": {
     "//paket:paket.main_extension.bzl%main_extension": {
       "general": {
-        "bzlTransitiveDigest": "/ND/EES4GD2yMYQ1XnID3G3chjk508XhECW9QHXsxiU=",
+        "bzlTransitiveDigest": "Qt6EhvIbcyINwpz7DO99PXkicxfRxr/qjpwhtN+KyNM=",
         "usagesDigest": "/++DsNDsPEafh99irUtCwOTCNp57HApeC8MUxM9rbUo=",
         "recordedInputs": [
           "REPO_MAPPING:,rules_dotnet rules_dotnet+",

--- a/src/libraries/BUILD.bazel
+++ b/src/libraries/BUILD.bazel
@@ -15,6 +15,76 @@ nowarn = [ "CS8500", "CS8969" ]
 
 exports_files([])
 
+# ── Minimal impl assemblies for JIT tests ─────────────────────────────
+# This subset is used by Core_Root_Minimal to reduce cache invalidation.
+# JIT tests only need basic runtime support; they don't use networking,
+# XML, serialization, etc. Changes to assemblies outside this set won't
+# invalidate the JIT test cache.
+filegroup(
+    name = "impl_netcoreapp_minimal",
+    srcs = [
+        # ── Core ──
+        "//src/coreclr/System.Private.CoreLib:impl_System.Private.CoreLib",
+        ":impl_System.Runtime",
+        ":impl_System.Private.Uri",
+        ":impl_Microsoft.Win32.Primitives",
+        "//src/libraries/shims/mscorlib:impl_mscorlib",
+
+        # ── Essential facade shims ──
+        "//src/libraries/shims/System.AppContext:impl_System.AppContext",
+        "//src/libraries/shims/System.Buffers:impl_System.Buffers",
+        "//src/libraries/shims/System.Diagnostics.Debug:impl_System.Diagnostics.Debug",
+        "//src/libraries/shims/System.Diagnostics.Tools:impl_System.Diagnostics.Tools",
+        "//src/libraries/shims/System.Globalization:impl_System.Globalization",
+        "//src/libraries/shims/System.Globalization.Calendars:impl_System.Globalization.Calendars",
+        "//src/libraries/shims/System.IO:impl_System.IO",
+        "//src/libraries/shims/System.IO.FileSystem:impl_System.IO.FileSystem",
+        "//src/libraries/shims/System.IO.FileSystem.Primitives:impl_System.IO.FileSystem.Primitives",
+        "//src/libraries/shims/System.Reflection:impl_System.Reflection",
+        "//src/libraries/shims/System.Reflection.Extensions:impl_System.Reflection.Extensions",
+        "//src/libraries/shims/System.Resources.Reader:impl_System.Resources.Reader",
+        "//src/libraries/shims/System.Resources.ResourceManager:impl_System.Resources.ResourceManager",
+        "//src/libraries/shims/System.Runtime.CompilerServices.Unsafe:impl_System.Runtime.CompilerServices.Unsafe",
+        "//src/libraries/shims/System.Runtime.Extensions:impl_System.Runtime.Extensions",
+        "//src/libraries/shims/System.Runtime.Handles:impl_System.Runtime.Handles",
+        "//src/libraries/shims/System.Runtime.InteropServices.RuntimeInformation:impl_System.Runtime.InteropServices.RuntimeInformation",
+        "//src/libraries/shims/System.Text.Encoding:impl_System.Text.Encoding",
+        "//src/libraries/shims/System.Threading.Tasks:impl_System.Threading.Tasks",
+        "//src/libraries/shims/System.Threading.Tasks.Extensions:impl_System.Threading.Tasks.Extensions",
+        "//src/libraries/shims/System.Threading.Timer:impl_System.Threading.Timer",
+        "//src/libraries/shims/System.ValueTuple:impl_System.ValueTuple",
+
+        # ── Essential real libraries ──
+        "//src/libraries/System.Collections:impl_System.Collections",
+        "//src/libraries/System.Collections.Concurrent:impl_System.Collections.Concurrent",
+        "//src/libraries/System.Collections.NonGeneric:impl_System.Collections.NonGeneric",
+        "//src/libraries/System.Console:impl_System.Console",
+        "//src/libraries/System.Linq:impl_System.Linq",
+        "//src/libraries/System.Memory:impl_System.Memory",
+        "//src/libraries/System.Numerics.Vectors:impl_System.Numerics.Vectors",
+        "//src/libraries/System.ObjectModel:impl_System.ObjectModel",
+        "//src/libraries/System.Runtime.InteropServices:impl_System.Runtime.InteropServices",
+        "//src/libraries/System.Runtime.Intrinsics:impl_System.Runtime.Intrinsics",
+        "//src/libraries/System.Runtime.Loader:impl_System.Runtime.Loader",
+        "//src/libraries/System.Text.Encoding.Extensions:impl_System.Text.Encoding.Extensions",
+        "//src/libraries/System.Threading:impl_System.Threading",
+        "//src/libraries/System.Threading.Overlapped:impl_System.Threading.Overlapped",
+        "//src/libraries/System.Threading.Thread:impl_System.Threading.Thread",
+        "//src/libraries/System.Threading.ThreadPool:impl_System.Threading.ThreadPool",
+
+        # ── Facades needed by threading/reflection ──
+        "//src/libraries/System.Diagnostics.Tracing:impl_System.Diagnostics.Tracing",
+        "//src/libraries/System.Reflection.Primitives:impl_System.Reflection.Primitives",
+        "//src/libraries/System.Reflection.Emit.ILGeneration:impl_System.Reflection.Emit.ILGeneration",
+        "//src/libraries/System.Reflection.Emit.Lightweight:impl_System.Reflection.Emit.Lightweight",
+        "//src/libraries/System.Reflection.TypeExtensions:impl_System.Reflection.TypeExtensions",
+        "//src/libraries/System.Reflection.Emit:impl_System.Reflection.Emit",
+        "//src/libraries/System.Reflection.Metadata:impl_System.Reflection.Metadata",
+        "//src/libraries/System.Collections.Immutable:impl_System.Collections.Immutable",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 ref_assembly_nowarns = [
     # Ref assemblies use 'throw null'
     "CS8597",

--- a/src/libraries/BUILD.bazel
+++ b/src/libraries/BUILD.bazel
@@ -9,28 +9,26 @@ load("defs.bzl",
     "netcoreapp_ref_assembly",
     "netcoreapp_impl_assembly",
     "ref_impl_pair",
-    "LIVE_REFPACK_DEPS")
+    "LIVE_REFPACK_DEPS",
+    "CORE_ROOT_IMPL_DEPS")
 
 nowarn = [ "CS8500", "CS8969" ]
 
 exports_files([])
 
 # ── Minimal impl assemblies for JIT tests ─────────────────────────────
-# This subset is used by Core_Root_Minimal to reduce cache invalidation.
-# JIT tests only need basic runtime support; they don't use networking,
-# XML, serialization, etc. Changes to assemblies outside this set won't
-# invalidate the JIT test cache.
+# This subset is used by Core_Root to reduce cache invalidation.
+# The list is defined in CORE_ROOT_LIBS (defs.bzl) to ensure compile-time
+# refs and runtime impls stay in sync.
 filegroup(
     name = "impl_netcoreapp_minimal",
-    srcs = [
-        # ── Core ──
+    srcs = CORE_ROOT_IMPL_DEPS + [
+        # Core runtime assemblies not in CORE_ROOT_LIBS (internal/shims)
         "//src/coreclr/System.Private.CoreLib:impl_System.Private.CoreLib",
-        ":impl_System.Runtime",
         ":impl_System.Private.Uri",
-        ":impl_Microsoft.Win32.Primitives",
         "//src/libraries/shims/mscorlib:impl_mscorlib",
 
-        # ── Essential facade shims ──
+        # Facade shims (type forwarders needed at runtime)
         "//src/libraries/shims/System.AppContext:impl_System.AppContext",
         "//src/libraries/shims/System.Buffers:impl_System.Buffers",
         "//src/libraries/shims/System.Diagnostics.Debug:impl_System.Diagnostics.Debug",
@@ -53,34 +51,6 @@ filegroup(
         "//src/libraries/shims/System.Threading.Tasks.Extensions:impl_System.Threading.Tasks.Extensions",
         "//src/libraries/shims/System.Threading.Timer:impl_System.Threading.Timer",
         "//src/libraries/shims/System.ValueTuple:impl_System.ValueTuple",
-
-        # ── Essential real libraries ──
-        "//src/libraries/System.Collections:impl_System.Collections",
-        "//src/libraries/System.Collections.Concurrent:impl_System.Collections.Concurrent",
-        "//src/libraries/System.Collections.NonGeneric:impl_System.Collections.NonGeneric",
-        "//src/libraries/System.Console:impl_System.Console",
-        "//src/libraries/System.Linq:impl_System.Linq",
-        "//src/libraries/System.Memory:impl_System.Memory",
-        "//src/libraries/System.Numerics.Vectors:impl_System.Numerics.Vectors",
-        "//src/libraries/System.ObjectModel:impl_System.ObjectModel",
-        "//src/libraries/System.Runtime.InteropServices:impl_System.Runtime.InteropServices",
-        "//src/libraries/System.Runtime.Intrinsics:impl_System.Runtime.Intrinsics",
-        "//src/libraries/System.Runtime.Loader:impl_System.Runtime.Loader",
-        "//src/libraries/System.Text.Encoding.Extensions:impl_System.Text.Encoding.Extensions",
-        "//src/libraries/System.Threading:impl_System.Threading",
-        "//src/libraries/System.Threading.Overlapped:impl_System.Threading.Overlapped",
-        "//src/libraries/System.Threading.Thread:impl_System.Threading.Thread",
-        "//src/libraries/System.Threading.ThreadPool:impl_System.Threading.ThreadPool",
-
-        # ── Facades needed by threading/reflection ──
-        "//src/libraries/System.Diagnostics.Tracing:impl_System.Diagnostics.Tracing",
-        "//src/libraries/System.Reflection.Primitives:impl_System.Reflection.Primitives",
-        "//src/libraries/System.Reflection.Emit.ILGeneration:impl_System.Reflection.Emit.ILGeneration",
-        "//src/libraries/System.Reflection.Emit.Lightweight:impl_System.Reflection.Emit.Lightweight",
-        "//src/libraries/System.Reflection.TypeExtensions:impl_System.Reflection.TypeExtensions",
-        "//src/libraries/System.Reflection.Emit:impl_System.Reflection.Emit",
-        "//src/libraries/System.Reflection.Metadata:impl_System.Reflection.Metadata",
-        "//src/libraries/System.Collections.Immutable:impl_System.Collections.Immutable",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/libraries/defs.bzl
+++ b/src/libraries/defs.bzl
@@ -25,6 +25,83 @@ LIVE_NETCOREAPP_DEPS = [
 #    "//src/libraries:live_System.Collections",
 ]
 
+# ── Core_Root library set ─────────────────────────────────────────────
+# This is the single source of truth for what libraries are available to
+# JIT/coreclr tests at both compile time (refs) and runtime (impls).
+# 
+# Format: (library_name, package_path_or_none)
+#   - If package_path is None, the target is at //src/libraries:ref_/impl_<name>
+#   - If package_path is a string, the target is at that path:ref_/impl_<name>
+#
+# IMPORTANT: If a JIT test needs a library, add it here. This ensures both
+# the ref (for compilation) and impl (for runtime) are available.
+CORE_ROOT_LIBS = [
+    # Core libraries (these have refs and impls at //src/libraries:)
+    ("System.Runtime", None),
+    ("Microsoft.Win32.Primitives", None),
+    ("System.ComponentModel.Primitives", None),
+    ("System.Diagnostics.Process", None),
+    
+    # Standard libraries with their own packages
+    ("System.Collections", "//src/libraries/System.Collections"),
+    ("System.Collections.Concurrent", "//src/libraries/System.Collections.Concurrent"),
+    ("System.Collections.Immutable", "//src/libraries/System.Collections.Immutable"),
+    ("System.Collections.NonGeneric", "//src/libraries/System.Collections.NonGeneric"),
+    ("System.Collections.Specialized", "//src/libraries/System.Collections.Specialized"),
+    ("System.ComponentModel", "//src/libraries/System.ComponentModel"),
+    ("System.Console", "//src/libraries/System.Console"),
+    ("System.Diagnostics.FileVersionInfo", "//src/libraries/System.Diagnostics.FileVersionInfo"),
+    ("System.Diagnostics.Tracing", "//src/libraries/System.Diagnostics.Tracing"),
+    ("System.IO.MemoryMappedFiles", "//src/libraries/System.IO.MemoryMappedFiles"),
+    ("System.Linq", "//src/libraries/System.Linq"),
+    ("System.Memory", "//src/libraries/System.Memory"),
+    ("System.Numerics.Vectors", "//src/libraries/System.Numerics.Vectors"),
+    ("System.ObjectModel", "//src/libraries/System.ObjectModel"),
+    ("System.Reflection.Emit", "//src/libraries/System.Reflection.Emit"),
+    ("System.Reflection.Emit.ILGeneration", "//src/libraries/System.Reflection.Emit.ILGeneration"),
+    ("System.Reflection.Emit.Lightweight", "//src/libraries/System.Reflection.Emit.Lightweight"),
+    ("System.Reflection.Metadata", "//src/libraries/System.Reflection.Metadata"),
+    ("System.Reflection.Primitives", "//src/libraries/System.Reflection.Primitives"),
+    ("System.Reflection.TypeExtensions", "//src/libraries/System.Reflection.TypeExtensions"),
+    ("System.Runtime.InteropServices", "//src/libraries/System.Runtime.InteropServices"),
+    ("System.Runtime.Intrinsics", "//src/libraries/System.Runtime.Intrinsics"),
+    ("System.Runtime.Loader", "//src/libraries/System.Runtime.Loader"),
+    ("System.Runtime.Numerics", "//src/libraries/System.Runtime.Numerics"),
+    ("System.Runtime.Serialization.Primitives", "//src/libraries/System.Runtime.Serialization.Primitives"),
+    ("System.Security.Cryptography", "//src/libraries/System.Security.Cryptography"),
+    ("System.Text.Encoding.Extensions", "//src/libraries/System.Text.Encoding.Extensions"),
+    ("System.Text.Encodings.Web", "//src/libraries/System.Text.Encodings.Web"),
+    ("System.Text.RegularExpressions", "//src/libraries/System.Text.RegularExpressions"),
+    ("System.Threading", "//src/libraries/System.Threading"),
+    ("System.Threading.Overlapped", "//src/libraries/System.Threading.Overlapped"),
+    ("System.Threading.Tasks.Parallel", "//src/libraries/System.Threading.Tasks.Parallel"),
+    ("System.Threading.Thread", "//src/libraries/System.Threading.Thread"),
+    ("System.Threading.ThreadPool", "//src/libraries/System.Threading.ThreadPool"),
+]
+
+def _lib_to_ref(lib_tuple):
+    """Convert a CORE_ROOT_LIBS entry to a ref assembly label."""
+    name, pkg = lib_tuple
+    if pkg:
+        return "%s:ref_%s" % (pkg, name)
+    else:
+        return "//src/libraries:ref_%s" % name
+
+def _lib_to_impl(lib_tuple):
+    """Convert a CORE_ROOT_LIBS entry to an impl assembly label."""
+    name, pkg = lib_tuple
+    if pkg:
+        return "%s:impl_%s" % (pkg, name)
+    else:
+        return "//src/libraries:impl_%s" % name
+
+# Ref assemblies for Core_Root - used by coreclr_test for compilation
+CORE_ROOT_REFPACK_DEPS = [_lib_to_ref(lib) for lib in CORE_ROOT_LIBS]
+
+# Impl assemblies for Core_Root - used at runtime (exported for BUILD.bazel)
+CORE_ROOT_IMPL_DEPS = [_lib_to_impl(lib) for lib in CORE_ROOT_LIBS]
+
+# Full refpack for library tests (superset of CORE_ROOT_REFPACK_DEPS)
 LIVE_REFPACK_DEPS = [
     # Roughly topologically sorted
     "//src/libraries:ref_System.Runtime",

--- a/src/tests/BUILD.bazel
+++ b/src/tests/BUILD.bazel
@@ -1,6 +1,26 @@
 load("//src/tests:live_test.bzl", "shared_testhost")
 
-# Shared testhost directory containing SDK + Core_Root assemblies.
+# Runtime binaries needed by shared_testhost.
+# This filegroup uses select() to pick platform-specific binaries,
+# which can't be done in rule attr defaults.
+filegroup(
+    name = "testhost_runtime_binaries",
+    srcs = [
+        "//src/native/corehost:hostpolicy",
+    ] + select({
+        "@platforms//os:macos": ["//src/coreclr/dlls/mscoree/coreclr:libcoreclr_dylib"],
+        "//conditions:default": ["//src/coreclr/dlls/mscoree/coreclr:libcoreclr.so"],
+    }) + select({
+        "@platforms//os:linux": [
+            "//src/coreclr/System.Private.CoreLib:crossgen_System.Private.CoreLib",
+            "//src/native/libs/System.Security.Cryptography.Native:System.Security.Cryptography.Native.OpenSsl",
+        ],
+        "@platforms//os:macos": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+# Shared testhost directory containing SDK + runtime assemblies.
 # Built once and referenced by all library tests to avoid redundant
 # ~90MB file copies per test (48 tests × 90MB = ~4.3GB eliminated).
 shared_testhost(

--- a/src/tests/JIT/Regression/JitBlue/Runtime_60035/BUILD.bazel
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_60035/BUILD.bazel
@@ -4,7 +4,4 @@ coreclr_test(
     name = "Runtime_60035",
     srcs = ["Runtime_60035.cs"],
     optimize = True,
-    deps = [
-        "//src/libraries/System.Text.Encodings.Web:ref_System.Text.Encodings.Web",
-    ],
 )

--- a/src/tests/live_test.bzl
+++ b/src/tests/live_test.bzl
@@ -412,25 +412,27 @@ def _generate_test_depsfile(ctx, dll, tfm, additional_runfiles):
 def _shared_testhost_impl(ctx):
     """Build a shared testhost directory that all library tests can reference.
 
-    This rule creates the testhost once, containing SDK + Core_Root assemblies.
+    This rule creates the testhost once, containing SDK + runtime assemblies.
     Individual tests reference this shared testhost instead of each building
     their own, eliminating ~90MB of redundant file copies per test.
     """
     toolchain = ctx.toolchains["@rules_dotnet//dotnet:toolchain_type"]
     dotnet_file = toolchain.dotnetinfo.runtime_files[0]
     sdk_version = toolchain.dotnetinfo.runtime_version
-    core_root = ctx.file.core_root
 
     testhost = ctx.actions.declare_directory("testhost")
 
+    # Collect all runtime files into a single list for the shell command
+    runtime_files = ctx.files.managed_assemblies + ctx.files.native_libs + ctx.files.runtime_binaries
+
     ctx.actions.run_shell(
-        inputs = [core_root, dotnet_file],
+        inputs = [dotnet_file] + runtime_files,
         outputs = [testhost],
         command = """\
 SDK_ROOT=$(dirname "$(readlink -f "$1")")
 VERSION="$2"
 OUT="$3"
-CORE_ROOT="$4"
+shift 3
 
 FW_DIR="$OUT/shared/Microsoft.NETCore.App/$VERSION"
 mkdir -p "$FW_DIR"
@@ -447,8 +449,10 @@ cp -aL "$SDK_ROOT/host/fxr/$VERSION/"* "$OUT/host/fxr/$VERSION/"
 # SDK shared framework as base (lowest priority)
 cp -aL "$SDK_ROOT/shared/Microsoft.NETCore.App/$VERSION/"* "$FW_DIR/"
 
-# Core_Root: Bazel-built runtime + managed assemblies override SDK
-cp -afL "$CORE_ROOT/"* "$FW_DIR/"
+# Copy Bazel-built runtime files (managed + native) over SDK
+for f in "$@"; do
+    cp -afL "$f" "$FW_DIR/"
+done
 
 # Generate a version-free deps.json matching MSBuild's testhost pattern.
 # The SDK's deps.json contains assemblyVersion/fileVersion constraints that
@@ -489,7 +493,7 @@ if [ -d "$REF_DIR" ]; then
     fi
 fi
 """,
-        arguments = [dotnet_file.path, sdk_version, testhost.path, core_root.path],
+        arguments = [dotnet_file.path, sdk_version, testhost.path] + [f.path for f in runtime_files],
         mnemonic = "BuildTestHost",
         progress_message = "Building shared testhost",
     )
@@ -500,10 +504,26 @@ _shared_testhost_rule = rule(
     _shared_testhost_impl,
     doc = """Build a shared testhost directory for library tests.""",
     attrs = {
-        "core_root": attr.label(
-            doc = "The Core_Root directory with Bazel-built runtime assemblies",
-            default = "//:Core_Root",
-            allow_single_file = True,
+        "managed_assemblies": attr.label(
+            doc = "Filegroup containing managed assemblies (impl_netcoreapp)",
+            default = "//src/libraries:impl_netcoreapp",
+            allow_files = True,
+        ),
+        "native_libs": attr.label_list(
+            doc = "Native libraries to include in the testhost",
+            default = [
+                "//src/native/libs/System.Native:System.Native",
+                "//src/native/libs/System.Globalization.Native:System.Globalization.Native",
+                "//src/native/libs/System.IO.Compression.Native:System.IO.Compression.Native",
+                "//src/native/libs/System.IO.Ports.Native:System.IO.Ports.Native",
+                "//src/native/libs/System.Net.Security.Native:System.Net.Security.Native",
+            ],
+            allow_files = True,
+        ),
+        "runtime_binaries": attr.label(
+            doc = "Filegroup containing runtime binaries (coreclr, hostpolicy, etc.)",
+            default = "//src/tests:testhost_runtime_binaries",
+            allow_files = True,
         ),
     },
     toolchains = ["@rules_dotnet//dotnet:toolchain_type"],

--- a/src/tests/live_test.bzl
+++ b/src/tests/live_test.bzl
@@ -1,4 +1,4 @@
-load("//:defs.bzl", "NETCOREAPP_CURRENT")
+load("//:defs.bzl", "NETCOREAPP_CURRENT", "csharp_library")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_dotnet//dotnet/private:providers.bzl",
@@ -16,7 +16,7 @@ load("@rules_dotnet//dotnet/private:common.bzl",
     "is_standard_framework",
     "to_rlocation_path",)
 load("@rules_dotnet//dotnet/private/macros:register_tfms.bzl", "get_tfm_value")
-load("//src/libraries:defs.bzl", "live_csharp_library", "LIVE_REFPACK_DEPS")
+load("//src/libraries:defs.bzl", "LIVE_REFPACK_DEPS", "CORE_ROOT_REFPACK_DEPS")
 load("//src/tests:defs.bzl", "COMMON_ATTRS", "build_binary", "create_launcher", "COPY_EXECUTION_REQUIREMENTS")
 
 # Match src/tests/Directory.Build.props NoWarn
@@ -620,36 +620,55 @@ def coreclr_test(
     use_shared_compilation = True,
     **kwargs
 ):
-    deps = deps + [
+    # Build complete deps list for JIT tests:
+    # 1. User deps (filtered to remove any already in CORE_ROOT_REFPACK_DEPS)
+    # 2. Xunit deps
+    # 3. CORE_ROOT_REFPACK_DEPS (refs matching impls in Core_Root)
+    core_root_set = {dep: True for dep in CORE_ROOT_REFPACK_DEPS}
+    filtered_deps = [dep for dep in deps if dep not in core_root_set]
+
+    all_deps = filtered_deps + [
         "@paket.main//microsoft.dotnet.xunitassert",
         "@paket.main//xunit.abstractions",
         "@paket.main//xunit.extensibility.core",
-    ]
+    ] + CORE_ROOT_REFPACK_DEPS
 
     compiler_options = [
         "/debug:%s" % debug_type,
         "/optimize%s" % ("" if optimize else "-"),
     ] + compiler_options
 
-    # Create two targets: a library for the merged runner and a test. We'll use one or the other.
-    live_csharp_library(
+    analyzers = [
+        "//src/tests/Common:XUnitWrapperGenerator",
+    ]
+
+    # Create a library target for the merged runner
+    csharp_library(
         name = name + "_lib",
-        deps = deps,
+        deps = all_deps,
         nowarn = _TEST_NOWARN,
         tags = tags,
         visibility = ["//visibility:public"],
         compiler_options = compiler_options,
+        langversion = "preview",
+        disable_implicit_framework_refs = True,
+        target_frameworks = [NETCOREAPP_CURRENT],
         use_shared_compilation = use_shared_compilation,
         **kwargs
     )
 
-    live_csharp_test(
+    # Create the test target - calls _live_csharp_test directly to bypass LIVE_REFPACK_DEPS
+    _live_csharp_test(
         name = name,
-        deps = deps,
+        deps = all_deps,
+        analyzers = analyzers,
         size = size,
-        tags = tags + [ "pri%d" % pri ],
+        tags = tags + ["pri%d" % pri],
         compiler_options = compiler_options,
+        target_frameworks = [NETCOREAPP_CURRENT],
+        nowarn = ["CS1701"] + _TEST_NOWARN,
         use_shared_compilation = use_shared_compilation,
+        shared_compilation_worker = _SHARED_COMPILATION_WORKER if use_shared_compilation else None,
         **kwargs
     )
 


### PR DESCRIPTION
Core_Root is used to run the coreclr tests. If we include everything in netcoreapp then every change to a netcoreapp library causes a rebuild/rerun of the coreclr unit tests since it's a changed to the reference set.

The coreclr tests only require a very small subset of the actual libraries, so we'll shrink things down to the most commonly used libraries.