### PR TITLE
Improve bazel caching by skipping PDBs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,7 @@
 bazel_dep(name = "rules_dotnet")
-git_override(
+local_path_override(
     module_name = "rules_dotnet",
-    remote = "https://github.com/agocke/rules_dotnet.git",
-    commit = "4e8c3811cd0cd1181d64021d2ee3333882c74deb",
+    path = "/home/andy/code/rules_dotnet",
 )
 
 dotnet = use_extension("@rules_dotnet//dotnet:extensions.bzl", "dotnet")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ bazel_dep(name = "rules_dotnet")
 git_override(
     module_name = "rules_dotnet",
     remote = "https://github.com/agocke/rules_dotnet.git",
-    commit = "24a42a333d9b600ca1b7f366d957394018d6b28c",
+    commit = "0907edc64e9513aa9b4967fae6e3f887b82fb8dc",
 )
 
 dotnet = use_extension("@rules_dotnet//dotnet:extensions.bzl", "dotnet")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,8 @@
 bazel_dep(name = "rules_dotnet")
-local_path_override(
+git_override(
     module_name = "rules_dotnet",
-    path = "/home/andy/code/rules_dotnet",
+    remote = "https://github.com/agocke/rules_dotnet.git",
+    commit = "24a42a333d9b600ca1b7f366d957394018d6b28c",
 )
 
 dotnet = use_extension("@rules_dotnet//dotnet:extensions.bzl", "dotnet")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -224,7 +224,7 @@
   "moduleExtensions": {
     "//paket:paket.main_extension.bzl%main_extension": {
       "general": {
-        "bzlTransitiveDigest": "WCZBW9nzDAJ6vmz3YGHCzFe7sRuZL9ZiV89HHoZTb5c=",
+        "bzlTransitiveDigest": "aGSTmSQsueY8lNOywfKLr67qKbLpqQoF2voAcV9JEVc=",
         "usagesDigest": "/++DsNDsPEafh99irUtCwOTCNp57HApeC8MUxM9rbUo=",
         "recordedInputs": [
           "REPO_MAPPING:,rules_dotnet rules_dotnet+",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -224,7 +224,7 @@
   "moduleExtensions": {
     "//paket:paket.main_extension.bzl%main_extension": {
       "general": {
-        "bzlTransitiveDigest": "aGSTmSQsueY8lNOywfKLr67qKbLpqQoF2voAcV9JEVc=",
+        "bzlTransitiveDigest": "DaqQaDVroF0SvuV8JZpig2Sf6Ziyw8oktD2CyBVaUwI=",
         "usagesDigest": "/++DsNDsPEafh99irUtCwOTCNp57HApeC8MUxM9rbUo=",
         "recordedInputs": [
           "REPO_MAPPING:,rules_dotnet rules_dotnet+",

--- a/src/libraries/System.Diagnostics.StackTrace/tests/BUILD.bazel
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/BUILD.bazel
@@ -12,8 +12,11 @@ live_csharp_library(
     # assertions about IL offsets still pass with debug info present.
 )
 
+# This test requires PDB files to exist (StackTraceSymbolsDoNotLockFile asserts
+# File.Exists(pdbPath)), so force PDB generation even in fastbuild mode.
 library_test(
     name = "System.Diagnostics.StackTrace.Tests",
+    debug_type = "portable",
     srcs = glob(
         ["*.cs"],
         exclude = ["ExceptionTestAssembly/**"],

--- a/src/libraries/defs.bzl
+++ b/src/libraries/defs.bzl
@@ -163,6 +163,7 @@ def netcoreapp_ref_assembly(
         nowarn = nowarn,
         compiler_options = compiler_options,
         ref_assembly = True,
+        debug_type = "none",
         **kwargs
     )
 

--- a/src/tests/defs.bzl
+++ b/src/tests/defs.bzl
@@ -190,6 +190,15 @@ COMMON_ATTRS = {
         mandatory = False,
         default = [],
     ),
+    "debug_type": attr.string(
+        doc = "Controls PDB / debug info generation, mirroring the csc /debug option. " +
+              "When set to 'auto' (the default), the debug type is derived from the " +
+              "Bazel compilation mode: 'portable' in opt/dbg, 'none' in fastbuild. " +
+              "Set to an explicit value to override (e.g. 'portable' for tests that " +
+              "require PDB files to exist at runtime).",
+        default = "auto",
+        values = ["auto", "portable", "embedded", "full", "pdbonly", "none"],
+    ),
     "use_shared_compilation": attr.bool(
         doc = "When True, uses the Roslyn compiler server via a Bazel persistent worker.",
         default = True,

--- a/src/tests/live_test.bzl
+++ b/src/tests/live_test.bzl
@@ -9,6 +9,7 @@ load("@rules_dotnet//dotnet/private/rules/csharp:binary.bzl", "compile_csharp_ex
 load("@rules_dotnet//dotnet/private/rules/csharp/actions:csharp_assembly.bzl", "AssemblyAction")
 load("@rules_dotnet//dotnet/private:common.bzl",
     "collect_transitive_runfiles",
+    "emit_pdb",
     "generate_runtimeconfig",
     "get_toolchain",
     "is_core_framework",
@@ -99,6 +100,7 @@ def _compile_csharp_library(ctx, tfm):
         additionalfiles = ctx.files.additionalfiles,
         direct_analyzers = ctx.attr.analyzers,
         debug = is_debug(ctx),
+        emit_pdb = emit_pdb(ctx),
         defines = ctx.attr.defines,
         deps = ctx.attr.deps,
         exports = [],

--- a/src/tests/live_test.bzl
+++ b/src/tests/live_test.bzl
@@ -9,12 +9,12 @@ load("@rules_dotnet//dotnet/private/rules/csharp:binary.bzl", "compile_csharp_ex
 load("@rules_dotnet//dotnet/private/rules/csharp/actions:csharp_assembly.bzl", "AssemblyAction")
 load("@rules_dotnet//dotnet/private:common.bzl",
     "collect_transitive_runfiles",
-    "emit_pdb",
     "generate_runtimeconfig",
     "get_toolchain",
     "is_core_framework",
     "is_debug",
     "is_standard_framework",
+    "resolve_debug_type",
     "to_rlocation_path",)
 load("@rules_dotnet//dotnet/private/macros:register_tfms.bzl", "get_tfm_value")
 load("//src/libraries:defs.bzl", "LIVE_REFPACK_DEPS", "CORE_ROOT_REFPACK_DEPS")
@@ -100,7 +100,7 @@ def _compile_csharp_library(ctx, tfm):
         additionalfiles = ctx.files.additionalfiles,
         direct_analyzers = ctx.attr.analyzers,
         debug = is_debug(ctx),
-        emit_pdb = emit_pdb(ctx),
+        debug_type = resolve_debug_type(ctx),
         defines = ctx.attr.defines,
         deps = ctx.attr.deps,
         exports = [],


### PR DESCRIPTION
Update live_test.bzl to pass the new emit_pdb parameter from
rules_dotnet, which suppresses PDB generation in fastbuild mode.

This ensures that comment-only source changes produce byte-identical
DLL outputs in the default build config, so Bazel skips rebuilding
downstream libraries and re-running tests.