### PR TITLE
Include matrix config in CI cache key to fix checked build caching

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -39,10 +39,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/bazel-disk
-          key: bazel-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelrc') }}-${{ github.sha }}
+          key: bazel-${{ runner.os }}-${{ matrix.config }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelrc') }}-${{ github.sha }}
           restore-keys: |
-            bazel-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelrc') }}-
-            bazel-${{ runner.os }}-
+            bazel-${{ runner.os }}-${{ matrix.config }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelrc') }}-
+            bazel-${{ runner.os }}-${{ matrix.config }}-
 
       - name: Build
         run: bazel build //... --config=${{ matrix.config }} --disk_cache=~/.cache/bazel-disk


### PR DESCRIPTION
The cache key did not include the build config (clr_release vs clr_checked), so both Linux jobs shared the same cache slot. Since release finishes first, only its artifacts were saved. Checked always got cache misses on restore.