### PR TITLE
Add module(name) declaration to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,5 @@
+module(name = "dotnet_runtime")
+
 bazel_dep(name = "rules_dotnet")
 git_override(
     module_name = "rules_dotnet",


### PR DESCRIPTION
Bazel requires a module(name = "dotnet_runtime") declaration when the runtime is consumed as a dependency via local_path_override (e.g. from the VMR). Without it, Bazel errors with 'declares a different name'.

This is a no-op for standalone builds (root modules are implicitly named).