### PR TITLE
Add automated release/10.0 → bazel branch sync

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -1,0 +1,371 @@
+name: Sync release/10.0 → bazel
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6:00 UTC
+  workflow_dispatch:
+    inputs:
+      skip_copilot_fix:
+        description: 'Skip Copilot SDK auto-fix attempt'
+        type: boolean
+        default: false
+      skip_equivalence:
+        description: 'Skip equivalence check'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # ─── Job 1: Merge upstream and create PR ────────────────────────────────────
+  merge-and-pr:
+    name: Merge & Create PR
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.create-pr.outputs.pr_number }}
+      sync_branch: ${{ steps.create-branch.outputs.branch }}
+      classification: ${{ steps.detect.outputs.classification }}
+      has_new_commits: ${{ steps.check-new.outputs.has_new_commits }}
+      report_file: ${{ steps.detect.outputs.report_file }}
+    steps:
+      - name: Checkout bazel branch
+        uses: actions/checkout@v5
+        with:
+          ref: bazel
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote and fetch
+        run: |
+          git remote add upstream https://github.com/dotnet/runtime.git || true
+          git fetch upstream release/10.0 --quiet
+
+      - name: Check for existing sync PR
+        id: check-existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          open_prs=$(gh pr list --base bazel --label bazel-sync --state open --json number --jq 'length')
+          if [ "$open_prs" -gt 0 ]; then
+            echo "has_open_pr=true" >> "$GITHUB_OUTPUT"
+            echo "An open sync PR already exists, skipping"
+          else
+            echo "has_open_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for new commits
+        id: check-new
+        if: steps.check-existing.outputs.has_open_pr == 'false'
+        run: |
+          # List unmerged upstream commits, oldest first
+          next_commit=$(git rev-list --reverse --ancestry-path origin/bazel..upstream/release/10.0 | head -1)
+          if [ -z "$next_commit" ]; then
+            echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
+            echo "Already up-to-date"
+          else
+            echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
+            echo "next_commit=$next_commit" >> "$GITHUB_OUTPUT"
+            remaining=$(git rev-list --count origin/bazel..upstream/release/10.0)
+            echo "next_commit_subject=$(git log -1 --format='%s' "$next_commit")" >> "$GITHUB_OUTPUT"
+            echo "next_commit_short=$(git rev-parse --short "$next_commit")" >> "$GITHUB_OUTPUT"
+            echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+            echo "Next commit: $next_commit (1 of $remaining pending)"
+          fi
+
+      - name: Create sync branch
+        id: create-branch
+        if: steps.check-new.outputs.has_new_commits == 'true'
+        run: |
+          short="${{ steps.check-new.outputs.next_commit_short }}"
+          branch="sync/release-10.0-${short}"
+          git checkout -b "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Merge single upstream commit
+        id: merge
+        if: steps.check-new.outputs.has_new_commits == 'true'
+        run: |
+          next_commit="${{ steps.check-new.outputs.next_commit }}"
+          if git merge "$next_commit" --no-edit; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Merge conflicts detected"
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            # Stage conflicted files so we can still create the PR
+            git add -A
+            git commit --no-edit -m "Merge $next_commit (with conflicts)" || true
+          fi
+
+      - name: Run change detection
+        id: detect
+        if: steps.check-new.outputs.has_new_commits == 'true'
+        run: |
+          report_file="/tmp/sync-report.md"
+          next_commit="${{ steps.check-new.outputs.next_commit }}"
+
+          if [ "${{ steps.merge.outputs.conflict }}" = "true" ]; then
+            echo "classification=conflict" >> "$GITHUB_OUTPUT"
+            echo "# Sync Report" > "$report_file"
+            echo "" >> "$report_file"
+            echo "**Classification:** ❌ **conflict** — Merge conflicts need manual resolution" >> "$report_file"
+            echo "" >> "$report_file"
+            echo "## Conflicted Files" >> "$report_file"
+            git diff --name-only --diff-filter=U HEAD || true >> "$report_file"
+          else
+            chmod +x src/tools/bazel/detect-upstream-changes.sh
+            set +e
+            ./src/tools/bazel/detect-upstream-changes.sh origin/bazel "$next_commit" \
+              --report-file "$report_file"
+            exit_code=$?
+            set -e
+
+            if [ "$exit_code" -eq 0 ]; then
+              echo "classification=clean" >> "$GITHUB_OUTPUT"
+            elif [ "$exit_code" -eq 1 ]; then
+              echo "classification=build-changes" >> "$GITHUB_OUTPUT"
+            else
+              echo "classification=unknown" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+          echo "report_file=$report_file" >> "$GITHUB_OUTPUT"
+
+      - name: Push sync branch
+        if: steps.check-new.outputs.has_new_commits == 'true'
+        run: |
+          git push origin "${{ steps.create-branch.outputs.branch }}"
+
+      - name: Create PR
+        id: create-pr
+        if: steps.check-new.outputs.has_new_commits == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          classification="${{ steps.detect.outputs.classification }}"
+          report_file="${{ steps.detect.outputs.report_file }}"
+          commit_subject="${{ steps.check-new.outputs.next_commit_subject }}"
+          commit_short="${{ steps.check-new.outputs.next_commit_short }}"
+          remaining="${{ steps.check-new.outputs.remaining }}"
+
+          case "$classification" in
+            clean)
+              title="✅ Sync ${commit_short}: ${commit_subject}"
+              labels="bazel-sync,bazel-sync-clean"
+              ;;
+            build-changes)
+              title="⚠️ Sync ${commit_short}: ${commit_subject}"
+              labels="bazel-sync,bazel-sync-needs-attention"
+              ;;
+            conflict)
+              title="❌ Sync ${commit_short}: ${commit_subject}"
+              labels="bazel-sync,bazel-sync-conflict"
+              ;;
+            *)
+              title="Sync ${commit_short}: ${commit_subject}"
+              labels="bazel-sync"
+              ;;
+          esac
+
+          # Prepend commit info to the report
+          commit_header="**Upstream commit:** [\`${commit_short}\`](https://github.com/dotnet/runtime/commit/${{ steps.check-new.outputs.next_commit }}) — ${commit_subject}"
+          commit_header+="\n**Remaining after this:** $((remaining - 1)) commit(s)\n\n---\n\n"
+          full_body=$(printf '%s' "$commit_header" && cat "$report_file")
+          echo "$full_body" > "$report_file"
+
+          pr_url=$(gh pr create \
+            --base bazel \
+            --head "${{ steps.create-branch.outputs.branch }}" \
+            --title "$title" \
+            --body-file "$report_file" \
+            --label "$labels" 2>&1 || true)
+
+          # Extract PR number from URL
+          pr_number=$(echo "$pr_url" | grep -oP '/pull/\K[0-9]+' || echo "")
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "Created PR: $pr_url"
+
+  # ─── Job 2: Equivalence check ──────────────────────────────────────────────
+  equivalence-check:
+    name: Equivalence Check
+    needs: merge-and-pr
+    if: >-
+      needs.merge-and-pr.outputs.has_new_commits == 'true' &&
+      needs.merge-and-pr.outputs.classification == 'build-changes' &&
+      github.event.inputs.skip_equivalence != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout sync branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.merge-and-pr.outputs.sync_branch }}
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y clang-18 lld libkrb5-dev liblttng-ust-dev
+
+      - name: Mount Bazel cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel-disk
+          key: bazel-equiv-${{ hashFiles('MODULE.bazel', '.bazelrc') }}-${{ github.sha }}
+          restore-keys: |
+            bazel-equiv-${{ hashFiles('MODULE.bazel', '.bazelrc') }}-
+            bazel-equiv-
+
+      - name: Build MSBuild runtime
+        run: ./build.sh clr+libs+host+packs -bl
+
+      - name: Build Bazel runtime archive
+        run: bazel build //:runtime_archive --config=clr_release --disk_cache=~/.cache/bazel-disk
+
+      - name: Compare runtime packs
+        id: compare-packs
+        continue-on-error: true
+        run: |
+          ./compare-runtime-packs.sh --skip-build 2>&1 | tee /tmp/packs-result.txt
+
+      - name: Compare build inputs
+        id: compare-build
+        continue-on-error: true
+        run: |
+          ./compare-bazel.sh --skip-build 2>&1 | tee /tmp/build-result.txt
+
+      - name: Post results to PR
+        if: needs.merge-and-pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          packs_status="${{ steps.compare-packs.outcome }}"
+          build_status="${{ steps.compare-build.outcome }}"
+
+          comment="## Equivalence Check Results\n\n"
+          comment+="| Check | Status |\n|-------|--------|\n"
+          comment+="| Runtime Packs | $([ "$packs_status" = "success" ] && echo "✅ Pass" || echo "❌ Fail") |\n"
+          comment+="| Build Inputs | $([ "$build_status" = "success" ] && echo "✅ Pass" || echo "❌ Fail") |\n\n"
+
+          if [ "$packs_status" != "success" ]; then
+            comment+="<details><summary>Runtime Packs Details</summary>\n\n\`\`\`\n$(tail -50 /tmp/packs-result.txt)\n\`\`\`\n</details>\n\n"
+          fi
+          if [ "$build_status" != "success" ]; then
+            comment+="<details><summary>Build Inputs Details</summary>\n\n\`\`\`\n$(tail -50 /tmp/build-result.txt)\n\`\`\`\n</details>\n"
+          fi
+
+          echo -e "$comment" | gh pr comment "${{ needs.merge-and-pr.outputs.pr_number }}" --body-file -
+
+  # ─── Job 3: Copilot SDK auto-fix ───────────────────────────────────────────
+  copilot-fix:
+    name: Copilot Auto-Fix
+    needs: merge-and-pr
+    if: >-
+      needs.merge-and-pr.outputs.has_new_commits == 'true' &&
+      (needs.merge-and-pr.outputs.classification == 'build-changes' ||
+       needs.merge-and-pr.outputs.classification == 'conflict') &&
+      github.event.inputs.skip_copilot_fix != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout sync branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.merge-and-pr.outputs.sync_branch }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
+
+      - name: Regenerate detection report
+        run: |
+          git fetch origin bazel --quiet
+          chmod +x src/tools/bazel/detect-upstream-changes.sh
+          ./src/tools/bazel/detect-upstream-changes.sh origin/bazel HEAD \
+            --report-file /tmp/sync-report.md || true
+
+      - name: Run Copilot fix
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+        run: |
+          cd src/tools/bazel
+          dotnet run CopilotFixSync.cs -- /tmp/sync-report.md
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Bazel dependencies
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y clang-18 lld libkrb5-dev liblttng-ust-dev
+
+      - name: Validate Bazel build
+        id: validate
+        if: steps.check-changes.outputs.has_changes == 'true'
+        continue-on-error: true
+        run: bazel build //... --config=clr_release --keep_going 2>&1 | tail -30
+
+      - name: Commit and push fixes
+        if: steps.check-changes.outputs.has_changes == 'true' && steps.validate.outcome == 'success'
+        run: |
+          git add -A
+          git commit -m "Auto-fix BUILD.bazel files for upstream sync
+
+          Applied by Copilot SDK based on detection report.
+
+          Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+          git push origin HEAD
+
+      - name: Comment on PR (success)
+        if: steps.check-changes.outputs.has_changes == 'true' && steps.validate.outcome == 'success' && needs.merge-and-pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ needs.merge-and-pr.outputs.pr_number }}" \
+            --body "🤖 **Copilot Auto-Fix Applied**
+
+          Copilot SDK automatically updated BUILD.bazel files based on the detection report. Changes have been pushed to the sync branch and validated with \`bazel build //...\`.
+
+          Please review the changes carefully before merging."
+
+      - name: Comment on PR (failure or no changes)
+        if: >-
+          (steps.check-changes.outputs.has_changes == 'false' ||
+           steps.validate.outcome != 'success') &&
+          needs.merge-and-pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.check-changes.outputs.has_changes }}" = "false" ]; then
+            msg="🤖 **Copilot Auto-Fix**: No changes were produced. Manual intervention needed."
+          else
+            msg="🤖 **Copilot Auto-Fix Failed**: Changes were produced but \`bazel build\` validation failed. Manual intervention needed."
+          fi
+          gh pr comment "${{ needs.merge-and-pr.outputs.pr_number }}" --body "$msg"
+
+      - name: Revert on validation failure
+        if: steps.check-changes.outputs.has_changes == 'true' && steps.validate.outcome != 'success'
+        run: git checkout -- .

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -191,6 +191,64 @@ The archive contains ~192 files: the `dotnet` host, `libhostfxr.so`,
 `libcoreclr.so`, native interop libraries, `createdump`, managed framework DLLs,
 config files (`deps.json`, `runtimeconfig.json`), and license files.
 
+## Syncing with release/10.0
+
+The `bazel` branch is a long-lived branch off `release/10.0`. A GitHub Action
+(`.github/workflows/sync-release.yml`) runs daily to keep it current, merging
+**one upstream commit at a time** to maintain a 1:1 correspondence between
+release/10.0 commits and bazel merge commits.
+
+### How the sync works
+
+1. **Check**: The workflow checks if there are unmerged upstream commits and
+   skips if an open sync PR already exists.
+2. **Pick next commit**: Takes the oldest unmerged commit from
+   `upstream/release/10.0` (one at a time).
+3. **Merge**: Merges that single commit into a new branch off `bazel`.
+4. **Detect**: A detection script (`src/tools/bazel/detect-upstream-changes.sh`)
+   analyzes the merge diff and classifies it:
+   - **clean** — Only `.cs` content changes, no new/removed files or build config
+     changes. Bazel build is unaffected.
+   - **build-changes** — New/removed `.cs` files in libraries with explicit
+     `srcs` lists, changed `.csproj`/`.props`/`.targets`/`CMakeLists.txt` files.
+     BUILD.bazel files may need updates.
+   - **conflict** — Git merge had conflicts requiring manual resolution.
+5. **PR**: A pull request is created with the upstream commit info, detection
+   report, and appropriate labels (`bazel-sync-clean`, `bazel-sync-needs-attention`,
+   `bazel-sync-conflict`).
+6. **Auto-fix** (build-changes/conflict only): A C# script using the GitHub
+   Copilot SDK (`src/tools/bazel/CopilotFixSync.cs`) attempts to automatically
+   update BUILD.bazel files based on the detection report.
+7. **Equivalence check** (build-changes only): Full MSBuild and Bazel builds are
+   run, followed by `compare-runtime-packs.sh` and `compare-bazel.sh` to verify
+   build equivalence. Results are posted as a PR comment.
+
+The workflow will not create a new sync PR while one is already open. Once the
+current PR is merged or closed, the next daily run picks up the next commit.
+
+### Running the detection script locally
+
+```bash
+# Compare current bazel branch against upstream
+./src/tools/bazel/detect-upstream-changes.sh origin/bazel upstream/release/10.0
+
+# Save report to a file
+./src/tools/bazel/detect-upstream-changes.sh origin/bazel upstream/release/10.0 \
+  --report-file /tmp/sync-report.md
+```
+
+Exit codes: `0` = clean, `1` = build-changes, `2` = conflict.
+
+### Key patterns to know when fixing BUILD.bazel files
+
+| MSBuild (.csproj) | Bazel (BUILD.bazel) |
+|--------------------|---------------------|
+| `<Compile Include="path">` | `srcs = ["src/path"]` |
+| `$(CoreLibSharedDir)path` | `"//src/libraries/System.Private.CoreLib:src/path"` |
+| `$(CommonPath)path` | `"//src/libraries/Common:src/path"` |
+| `<ProjectReference Include="...">` | `deps = ["//src/libraries:ref_AssemblyName"]` |
+| `<DefineConstants>FOO</DefineConstants>` | `defines = ["FOO"]` |
+
 ## Platform Support Status
 
 CMake currently supports all of these OS × architecture combinations. Bazel support status is tracked below.

--- a/src/tools/bazel/CopilotFixSync.cs
+++ b/src/tools/bazel/CopilotFixSync.cs
@@ -1,0 +1,145 @@
+// CopilotFixSync.cs
+//
+// Uses the GitHub Copilot SDK for .NET to automatically attempt BUILD.bazel
+// fixes based on a sync detection report.
+//
+// Usage: dotnet run CopilotFixSync.cs -- <report-file-path>
+//
+// Requires:
+//   - GitHub.Copilot.SDK NuGet package
+//   - Copilot CLI installed and authenticated (COPILOT_GITHUB_TOKEN env var)
+
+#:package GitHub.Copilot.SDK@*
+
+using GitHub.Copilot.SDK;
+
+if (args.Length < 1)
+{
+    Console.Error.WriteLine("Usage: dotnet run CopilotFixSync.cs -- <report-file-path>");
+    return 1;
+}
+
+var reportPath = args[0];
+if (!File.Exists(reportPath))
+{
+    Console.Error.WriteLine($"Report file not found: {reportPath}");
+    return 1;
+}
+
+var detectionReport = File.ReadAllText(reportPath);
+
+Console.WriteLine("Starting Copilot SDK session...");
+
+await using var client = new CopilotClient();
+await client.StartAsync();
+
+await using var session = await client.CreateSessionAsync(new SessionConfig
+{
+    Model = "claude-sonnet-4"
+});
+
+var completionSource = new TaskCompletionSource();
+
+session.On(evt =>
+{
+    switch (evt)
+    {
+        case AssistantMessageEvent msg:
+            Console.WriteLine(msg.Data.Content);
+            break;
+        case SessionErrorEvent err:
+            Console.Error.WriteLine($"[Error]: {err.Data.Message}");
+            completionSource.TrySetException(new InvalidOperationException(err.Data.Message));
+            break;
+        case SessionIdleEvent:
+            completionSource.TrySetResult();
+            break;
+    }
+});
+
+var prompt = $"""
+    You are updating Bazel BUILD files for the dotnet/runtime repository after
+    merging upstream changes from release/10.0 into the bazel branch.
+
+    ## Context: How BUILD.bazel files work in this repository
+
+    Libraries under src/libraries/ have BUILD.bazel files that define Bazel build
+    targets. The key patterns are:
+
+    1. **Explicit srcs lists**: Most libraries list source files explicitly:
+       ```
+       srcs = [
+           "src/System/Collections/Generic/LinkedList.cs",
+           "src/System/Collections/ThrowHelper.cs",
+       ]
+       ```
+
+    2. **Glob patterns**: Some libraries use glob() which auto-includes files:
+       ```
+       srcs = glob(["src/System/**/*.cs"])
+       ```
+       Files in glob-based libraries are auto-included and need no changes.
+
+    3. **Cross-package references**: Shared source files use Bazel labels:
+       - `$(CoreLibSharedDir)path` in MSBuild → `"//src/libraries/System.Private.CoreLib:src/path"` in Bazel
+       - `$(CommonPath)path` in MSBuild → `"//src/libraries/Common:src/path"` in Bazel
+
+    4. **Dependencies**: `<ProjectReference>` in .csproj → `deps` list in BUILD.bazel:
+       - `//src/libraries:ref_<AssemblyName>` for reference assemblies
+       - `//src/libraries:impl_<AssemblyName>` for implementation assemblies
+
+    5. **Defines**: `<DefineConstants>` in .csproj → `defines` list in BUILD.bazel
+
+    ## Detection Report
+
+    {detectionReport}
+
+    ## Instructions
+
+    Based on the detection report above, make the necessary changes to BUILD.bazel
+    files. For each item flagged as needing a BUILD.bazel update:
+
+    - **New .cs files (explicit srcs)**: Add the file path to the `srcs` list in
+      the appropriate BUILD.bazel file. Use the relative path from the library root
+      (e.g., "src/System/Foo.cs"). Maintain alphabetical ordering within the list.
+
+    - **Removed .cs files (explicit srcs)**: Remove the file path from the `srcs`
+      list in the appropriate BUILD.bazel file.
+
+    - **New ProjectReferences in .csproj**: Add the corresponding
+      `//src/libraries:ref_<AssemblyName>` entry to the `deps` list.
+
+    - **New DefineConstants in .csproj**: Add the constant to the `defines` list.
+
+    - **New .resx files**: Add a `resx_file` parameter if not already present.
+
+    If no BUILD.bazel changes are needed (e.g., all changes are in glob-based
+    libraries or are version-only bumps), make no changes and explain why.
+
+    Only modify BUILD.bazel files. Do not modify any other files.
+    """;
+
+await session.SendAsync(new UserMessageEvent
+{
+    Data = new UserMessageEventData
+    {
+        Content = prompt
+    }
+});
+
+// Wait for the session to complete its work
+using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+try
+{
+    await completionSource.Task.WaitAsync(cts.Token);
+}
+catch (OperationCanceledException)
+{
+    Console.Error.WriteLine("Copilot session timed out after 10 minutes");
+    return 1;
+}
+
+await client.StopAsync();
+
+Console.WriteLine("Copilot session completed.");
+return 0;

--- a/src/tools/bazel/detect-upstream-changes.sh
+++ b/src/tools/bazel/detect-upstream-changes.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# detect-upstream-changes.sh
+#
+# Analyzes a merge diff between the bazel branch and upstream/release/10.0 to
+# identify changes that may require Bazel BUILD file updates.
+#
+# Usage:
+#   ./eng/bazel/detect-upstream-changes.sh <base-ref> <head-ref> [--report-file <path>]
+#
+# Arguments:
+#   base-ref    The base commit (e.g., origin/bazel)
+#   head-ref    The head commit (e.g., upstream/release/10.0 or HEAD after merge)
+#
+# Options:
+#   --report-file <path>   Write the Markdown report to a file (default: stdout)
+#
+# Exit codes:
+#   0 = clean        (no Bazel-relevant changes)
+#   1 = build-changes (build-relevant changes detected)
+#   2 = conflict     (reserved for caller to set when merge had conflicts)
+
+set -euo pipefail
+
+BASE_REF=""
+HEAD_REF=""
+REPORT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --report-file)
+            REPORT_FILE="$2"
+            shift 2
+            ;;
+        *)
+            if [[ -z "$BASE_REF" ]]; then
+                BASE_REF="$1"
+            elif [[ -z "$HEAD_REF" ]]; then
+                HEAD_REF="$1"
+            else
+                echo "Error: unexpected argument: $1" >&2
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$BASE_REF" || -z "$HEAD_REF" ]]; then
+    echo "Usage: $0 <base-ref> <head-ref> [--report-file <path>]" >&2
+    exit 2
+fi
+
+# Use three-dot diff to get only upstream-side changes (not bazel-only changes)
+DIFF_RANGE="${BASE_REF}...${HEAD_REF}"
+
+has_build_changes=false
+report=""
+
+append() {
+    report+="$1"$'\n'
+}
+
+# ─── Section: New .cs files ───────────────────────────────────────────────────
+
+new_cs_files=$(git diff --diff-filter=A --name-only "$DIFF_RANGE" -- '*.cs' 2>/dev/null || true)
+
+if [[ -n "$new_cs_files" ]]; then
+    append "## ➕ New C# Source Files"
+    append ""
+
+    needs_update_files=""
+    auto_included_files=""
+    no_build_files=""
+
+    while IFS= read -r file; do
+        # Determine which library this file belongs to
+        lib_name=""
+        build_file=""
+
+        if [[ "$file" == src/libraries/* ]]; then
+            # Extract library name: src/libraries/<LibName>/...
+            lib_name=$(echo "$file" | cut -d'/' -f3)
+            build_file="src/libraries/${lib_name}/BUILD.bazel"
+        elif [[ "$file" == src/coreclr/* ]]; then
+            # For coreclr, find the nearest BUILD.bazel
+            dir=$(dirname "$file")
+            while [[ "$dir" != "src/coreclr" && "$dir" != "." ]]; do
+                if [[ -f "$dir/BUILD.bazel" ]]; then
+                    build_file="$dir/BUILD.bazel"
+                    lib_name="coreclr/$(basename "$dir")"
+                    break
+                fi
+                dir=$(dirname "$dir")
+            done
+        elif [[ "$file" == src/native/* ]]; then
+            dir=$(dirname "$file")
+            while [[ "$dir" != "src/native" && "$dir" != "." ]]; do
+                if [[ -f "$dir/BUILD.bazel" ]]; then
+                    build_file="$dir/BUILD.bazel"
+                    lib_name="native/$(basename "$dir")"
+                    break
+                fi
+                dir=$(dirname "$dir")
+            done
+        fi
+
+        if [[ -z "$build_file" || ! -f "$build_file" ]]; then
+            no_build_files+="- \`$file\` — no BUILD.bazel found"$'\n'
+        elif grep -q 'glob(' "$build_file" 2>/dev/null; then
+            auto_included_files+="- \`$file\` (\`$lib_name\` — uses glob, likely auto-included)"$'\n'
+        else
+            needs_update_files+="- \`$file\` (\`$lib_name\` — **explicit srcs, needs BUILD.bazel update**)"$'\n'
+            has_build_changes=true
+        fi
+    done <<< "$new_cs_files"
+
+    if [[ -n "$needs_update_files" ]]; then
+        append "### ⚠️ Needs BUILD.bazel update (explicit srcs)"
+        append "$needs_update_files"
+    fi
+    if [[ -n "$auto_included_files" ]]; then
+        append "### ✅ Auto-included (glob pattern)"
+        append "$auto_included_files"
+    fi
+    if [[ -n "$no_build_files" ]]; then
+        append "### ℹ️ No BUILD.bazel file"
+        append "$no_build_files"
+    fi
+fi
+
+# ─── Section: Removed .cs files ──────────────────────────────────────────────
+
+removed_cs_files=$(git diff --diff-filter=D --name-only "$DIFF_RANGE" -- '*.cs' 2>/dev/null || true)
+
+if [[ -n "$removed_cs_files" ]]; then
+    append "## ➖ Removed C# Source Files"
+    append ""
+
+    while IFS= read -r file; do
+        lib_name=""
+        build_file=""
+
+        if [[ "$file" == src/libraries/* ]]; then
+            lib_name=$(echo "$file" | cut -d'/' -f3)
+            build_file="src/libraries/${lib_name}/BUILD.bazel"
+        fi
+
+        if [[ -n "$build_file" && -f "$build_file" ]]; then
+            if grep -q 'glob(' "$build_file" 2>/dev/null; then
+                append "- \`$file\` (\`$lib_name\` — uses glob, auto-removed)"
+            else
+                append "- \`$file\` (\`$lib_name\` — **explicit srcs, needs BUILD.bazel update**)"
+                has_build_changes=true
+            fi
+        else
+            append "- \`$file\` — no BUILD.bazel found"
+        fi
+    done <<< "$removed_cs_files"
+    append ""
+fi
+
+# ─── Section: Modified .csproj files ─────────────────────────────────────────
+
+changed_csproj=$(git diff --name-only "$DIFF_RANGE" -- '*.csproj' 2>/dev/null || true)
+
+if [[ -n "$changed_csproj" ]]; then
+    # Filter to only src/ csproj files (skip eng/, tests that aren't in Bazel, etc.)
+    relevant_csproj=""
+    while IFS= read -r file; do
+        if [[ "$file" == src/libraries/*/src/*.csproj || "$file" == src/coreclr/*.csproj ]]; then
+            relevant_csproj+="$file"$'\n'
+        fi
+    done <<< "$changed_csproj"
+
+    if [[ -n "$relevant_csproj" ]]; then
+        append "## 📦 Modified Project Files (.csproj)"
+        append ""
+        append "These may affect Bazel deps, defines, or compilation settings:"
+        append ""
+        while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            lib_name=$(echo "$file" | cut -d'/' -f3)
+            # Show what changed in the csproj
+            changes=$(git diff "$DIFF_RANGE" -- "$file" 2>/dev/null | grep '^[+-]' | grep -v '^[+-][+-][+-]' | grep -iE 'Compile|Reference|DefineConstants|AllowUnsafe|TargetFramework|Condition' | head -10 || true)
+            append "- \`$file\` (\`$lib_name\`)"
+            if [[ -n "$changes" ]]; then
+                append '  ```diff'
+                append "  $changes"
+                append '  ```'
+                has_build_changes=true
+            fi
+        done <<< "$relevant_csproj"
+        append ""
+    fi
+fi
+
+# ─── Section: Modified .props/.targets files ─────────────────────────────────
+
+changed_props=$(git diff --name-only "$DIFF_RANGE" -- '*.props' '*.targets' 2>/dev/null || true)
+
+if [[ -n "$changed_props" ]]; then
+    # Filter to relevant build files
+    relevant_props=""
+    while IFS= read -r file; do
+        if [[ "$file" == src/libraries/* || "$file" == src/coreclr/* || "$file" == eng/* || "$file" == Directory.Build.* ]]; then
+            relevant_props+="$file"$'\n'
+        fi
+    done <<< "$changed_props"
+
+    if [[ -n "$relevant_props" ]]; then
+        append "## 🔧 Modified Build Properties (.props/.targets)"
+        append ""
+        append "These may affect compilation defines, references, or file includes:"
+        append ""
+        while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            # Version-only changes in eng/ are informational, not Bazel-breaking
+            is_version_only=false
+            if [[ "$file" == eng/Version.Details.props || "$file" == eng/Versions.props ]]; then
+                is_version_only=true
+            fi
+
+            changes=$(git diff "$DIFF_RANGE" -- "$file" 2>/dev/null | grep '^[+-]' | grep -v '^[+-][+-][+-]' | grep -iE 'DefineConstants|Reference|Compile|Condition|Property|Version' | head -10 || true)
+            if [[ "$is_version_only" == true ]]; then
+                append "- \`$file\` _(version bump, informational)_"
+            else
+                append "- \`$file\`"
+            fi
+            if [[ -n "$changes" ]]; then
+                append '  ```diff'
+                append "  $changes"
+                append '  ```'
+                if [[ "$is_version_only" == false ]]; then
+                    has_build_changes=true
+                fi
+            fi
+        done <<< "$relevant_props"
+        append ""
+    fi
+fi
+
+# ─── Section: Modified CMakeLists.txt ─────────────────────────────────────────
+
+changed_cmake=$(git diff --name-only "$DIFF_RANGE" -- '*CMakeLists.txt' '*.cmake' 2>/dev/null || true)
+
+if [[ -n "$changed_cmake" ]]; then
+    append "## 🛠️ Modified Native Build Files (CMake)"
+    append ""
+    append "These may affect native cc_library targets in Bazel:"
+    append ""
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        append "- \`$file\`"
+        has_build_changes=true
+    done <<< "$changed_cmake"
+    append ""
+fi
+
+# ─── Section: New/removed .resx files ─────────────────────────────────────────
+
+new_resx=$(git diff --diff-filter=A --name-only "$DIFF_RANGE" -- '*.resx' 2>/dev/null || true)
+removed_resx=$(git diff --diff-filter=D --name-only "$DIFF_RANGE" -- '*.resx' 2>/dev/null || true)
+
+if [[ -n "$new_resx" || -n "$removed_resx" ]]; then
+    append "## 📝 New/Removed Resource Files (.resx)"
+    append ""
+    if [[ -n "$new_resx" ]]; then
+        while IFS= read -r file; do
+            append "- ➕ \`$file\`"
+            has_build_changes=true
+        done <<< "$new_resx"
+    fi
+    if [[ -n "$removed_resx" ]]; then
+        while IFS= read -r file; do
+            append "- ➖ \`$file\`"
+            has_build_changes=true
+        done <<< "$removed_resx"
+    fi
+    append ""
+fi
+
+# ─── Section: New test projects ───────────────────────────────────────────────
+
+new_test_csproj=$(git diff --diff-filter=A --name-only "$DIFF_RANGE" -- '*Tests.csproj' '*Tests/*.csproj' 2>/dev/null || true)
+
+if [[ -n "$new_test_csproj" ]]; then
+    append "## 🧪 New Test Projects"
+    append ""
+    while IFS= read -r file; do
+        append "- \`$file\`"
+        has_build_changes=true
+    done <<< "$new_test_csproj"
+    append ""
+fi
+
+# ─── Section: New C/C++ source files ──────────────────────────────────────────
+
+new_native_files=$(git diff --diff-filter=A --name-only "$DIFF_RANGE" -- '*.c' '*.cpp' '*.h' '*.S' 2>/dev/null | grep -E '^src/(coreclr|native)/' || true)
+
+if [[ -n "$new_native_files" ]]; then
+    append "## 🔩 New Native Source Files"
+    append ""
+    while IFS= read -r file; do
+        append "- \`$file\`"
+        has_build_changes=true
+    done <<< "$new_native_files"
+    append ""
+fi
+
+removed_native_files=$(git diff --diff-filter=D --name-only "$DIFF_RANGE" -- '*.c' '*.cpp' '*.h' '*.S' 2>/dev/null | grep -E '^src/(coreclr|native)/' || true)
+
+if [[ -n "$removed_native_files" ]]; then
+    append "## 🔩 Removed Native Source Files"
+    append ""
+    while IFS= read -r file; do
+        append "- \`$file\`"
+        has_build_changes=true
+    done <<< "$removed_native_files"
+    append ""
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+
+# Use two-dot for commit count (commits on HEAD_REF not on BASE_REF)
+total_upstream_commits=$(git rev-list --count "$BASE_REF".."$HEAD_REF" 2>/dev/null || echo "?")
+# Use three-dot for file count (same as DIFF_RANGE used for file analysis)
+total_files_changed=$(git diff --name-only "$DIFF_RANGE" 2>/dev/null | wc -l | tr -d ' ')
+
+header="# Sync Report: \`release/10.0\` → \`bazel\`"$'\n'$'\n'
+header+="**Upstream commits:** ${total_upstream_commits} | **Files changed:** ${total_files_changed}"$'\n'$'\n'
+
+if [[ "$has_build_changes" == true ]]; then
+    header+="**Classification:** ⚠️ **build-changes** — Bazel-relevant changes detected, review needed"$'\n'$'\n'
+else
+    header+="**Classification:** ✅ **clean** — No Bazel-relevant build changes detected"$'\n'$'\n'
+fi
+
+full_report="${header}${report}"
+
+if [[ -z "$report" ]]; then
+    full_report+="No Bazel-relevant changes detected in the upstream diff."$'\n'
+fi
+
+# Output
+if [[ -n "$REPORT_FILE" ]]; then
+    echo "$full_report" > "$REPORT_FILE"
+    echo "Report written to $REPORT_FILE" >&2
+else
+    echo "$full_report"
+fi
+
+# Exit code
+if [[ "$has_build_changes" == true ]]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
Adds a GitHub Action workflow and supporting tools to keep the bazel branch up-to-date with upstream release/10.0 changes, merging one commit at a time to maintain 1:1 correspondence.

Components:
- .github/workflows/sync-release.yml: Daily scheduled workflow with three jobs: merge-and-pr (merges single next upstream commit, creates classified PR), equivalence-check (runs compare scripts for build-changes), copilot-fix (uses Copilot SDK to auto-fix BUILD.bazel)
- src/tools/bazel/detect-upstream-changes.sh: Analyzes merge diffs for Bazel-relevant changes (new/removed .cs files, .csproj/.props/.targets changes, CMakeLists.txt changes) and classifies as clean/build-changes
- src/tools/bazel/CopilotFixSync.cs: C# script using GitHub.Copilot.SDK to automatically attempt BUILD.bazel fixes based on detection report
- docs/bazel.md: Documents the sync process and key BUILD.bazel patterns