### PR TITLE
Fix sync workflow: remove --ancestry-path from rev-list

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.check-existing.outputs.has_open_pr == 'false'
         run: |
           # List unmerged upstream commits, oldest first
-          next_commit=$(git rev-list --reverse --ancestry-path origin/bazel..upstream/release/10.0 | head -1)
+          next_commit=$(git rev-list --reverse origin/bazel..upstream/release/10.0 | head -1)
           if [ -z "$next_commit" ]; then
             echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
             echo "Already up-to-date"


### PR DESCRIPTION
The --ancestry-path flag filters to only commits on the direct lineage between two refs. Since the bazel branch diverged from release/10.0, there is no direct ancestry path, causing the workflow to report 0 pending commits even though there are 18.

Removing the flag lets git rev-list correctly enumerate all commits on upstream/release/10.0 that aren't in origin/bazel.