### PR TITLE
Improve test caching

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1120,7 +1120,7 @@
     },
     "@@rules_dotnet+//dotnet:extensions.bzl%dotnet": {
       "general": {
-        "bzlTransitiveDigest": "OoMLw4H6BlfZuC3Ad69y8l86ojdEml50mSAF5v6asa8=",
+        "bzlTransitiveDigest": "VMsIkFmKRdfrAu3izU2wlsTSPfkgTnxUpU+0IOXr73U=",
         "usagesDigest": "q1SUXJ+nNFchinUkos7c7TtLUrR7boEas/g++LUHj60=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/eng/run_library_test.sh.tpl
+++ b/eng/run_library_test.sh.tpl
@@ -22,7 +22,10 @@ ENTRY_DLL="$(rlocation TEMPLATED_entry_dll)"
 DEPSFILE="$(rlocation TEMPLATED_depsfile)"
 RUNTIMECONFIG="$(rlocation TEMPLATED_runtimeconfig)"
 
-RESOLVED_DIR="$(dirname "$(readlink -f "$XUNIT_CONSOLE")")"
+# Resolve the directory containing test outputs. Use pwd -P to resolve
+# directory-level symlinks but preserve file-level symlinks (which Bazel
+# uses for efficiency via ctx.actions.symlink).
+RESOLVED_DIR="$(cd "$(dirname "$XUNIT_CONSOLE")" && pwd -P)"
 
 if [ "TEMPLATED_writable_test_dir" = "true" ]; then
     # Copy all runtime files to a writable directory.  Bazel's linux-sandbox
@@ -30,8 +33,9 @@ if [ "TEMPLATED_writable_test_dir" = "true" ]; then
     # File.Move on files next to the assembly (e.g. PDB rename).
     WORK_DIR="${TEST_TMPDIR:-/tmp}/testdir"
     mkdir -p "$WORK_DIR"
-    # Copy everything including subdirectories (test data), then make writable.
-    cp -a "$RESOLVED_DIR"/. "$WORK_DIR/"
+    # Copy everything including subdirectories (test data), dereferencing
+    # symlinks (-L) so the work dir contains real writable files.
+    cp -RL "$RESOLVED_DIR"/. "$WORK_DIR/"
     chmod -R u+w "$WORK_DIR"
     cd "$WORK_DIR"
     XUNIT_CONSOLE="$WORK_DIR/$(basename "$XUNIT_CONSOLE")"

--- a/src/tests/defs.bzl
+++ b/src/tests/defs.bzl
@@ -319,36 +319,6 @@ def create_launcher(ctx, runfiles, entry_dll):
 
     return launcher
 
-# Hints for Bazel spawn strategy
-COPY_EXECUTION_REQUIREMENTS = {
-    # ----------------+-----------------------------------------------------------------------------
-    # no-remote       | Prevents the action or test from being executed remotely or cached remotely.
-    #                 | This is equivalent to using both `no-remote-cache` and `no-remote-exec`.
-    # ----------------+-----------------------------------------------------------------------------
-    # no-cache        | Results in the action or test never being cached (remotely or locally)
-    # ----------------+-----------------------------------------------------------------------------
-    # See https://bazel.build/reference/be/common-definitions#common-attributes
-    #
-    # Copying file & directories is entirely IO-bound and there is no point doing this work
-    # remotely.
-    #
-    # Also, remote-execution does not allow source directory inputs, see
-    # https://github.com/bazelbuild/bazel/commit/c64421bc35214f0414e4f4226cc953e8c55fa0d2 So we must
-    # not attempt to execute remotely in that case.
-    #
-    # There is also no point pulling the output file or directory from the remote cache since the
-    # bytes to copy are already available locally. Conversely, no point in writing to the cache if
-    # no one has any reason to check it for this action.
-    #
-    # Read and writing to disk cache is disabled as well primarily to reduce disk usage on the local
-    # machine. A disk cache hit of a directory copy could be slghtly faster than a copy since the
-    # disk cache stores the directory artifact as a single entry, but the slight performance bump
-    # comes at the cost of heavy disk cache usage, which is an unmanaged directory that grow beyond
-    # the bounds of the physical disk.
-    "no-remote": "1",
-    "no-cache": "1",
-}
-
 def build_binary(ctx, compile_action):
     """Builds a .Net binary from a compilation action
 
@@ -418,17 +388,10 @@ def build_binary(ctx, compile_action):
     for dep in transitive_runtime_deps:
         for lib in dep.libs:
             if lib.extension == "dll":
-                src = lib
                 dst = ctx.actions.declare_file("%s/%s/%s" % (ctx.label.name, tfm, lib.basename))
-                ctx.actions.run_shell(
-                    inputs = [src],
-                    outputs = [dst],
-                    command = "cp -f \"$1\" \"$2\"",
-                    arguments = [src.path, dst.path],
-                    mnemonic = "CopyFile",
-                    progress_message = "Copying files",
-                    use_default_shell_env = True,
-                    execution_requirements = COPY_EXECUTION_REQUIREMENTS,
+                ctx.actions.symlink(
+                    output = dst,
+                    target_file = lib,
                 )
                 additional_runfiles.append(dst)
 

--- a/src/tests/live_test.bzl
+++ b/src/tests/live_test.bzl
@@ -18,7 +18,7 @@ load("@rules_dotnet//dotnet/private:common.bzl",
     "to_rlocation_path",)
 load("@rules_dotnet//dotnet/private/macros:register_tfms.bzl", "get_tfm_value")
 load("//src/libraries:defs.bzl", "LIVE_REFPACK_DEPS", "CORE_ROOT_REFPACK_DEPS")
-load("//src/tests:defs.bzl", "COMMON_ATTRS", "build_binary", "create_launcher", "COPY_EXECUTION_REQUIREMENTS")
+load("//src/tests:defs.bzl", "COMMON_ATTRS", "build_binary", "create_launcher")
 
 # Match src/tests/Directory.Build.props NoWarn
 _TEST_NOWARN = [
@@ -155,19 +155,13 @@ def _xunit_library_test_impl(ctx):
     dll = runtime_provider.libs[0]
     additional_runfiles = list(runtime_provider.pdbs)
 
-    # Copy the xunit console runner files to the same output directory as the test DLL.
+    # Symlink the xunit console runner files to the same output directory as the test DLL.
     xunit_console_dll = None
     for f in ctx.files._xunit_runner:
         dst = ctx.actions.declare_file("%s/%s/%s" % (ctx.label.name, tfm, f.basename))
-        ctx.actions.run_shell(
-            inputs = [f],
-            outputs = [dst],
-            command = "cp -f \"$1\" \"$2\"",
-            arguments = [f.path, dst.path],
-            mnemonic = "CopyFile",
-            progress_message = "Copying %s" % f.basename,
-            use_default_shell_env = True,
-            execution_requirements = COPY_EXECUTION_REQUIREMENTS,
+        ctx.actions.symlink(
+            output = dst,
+            target_file = f,
         )
         additional_runfiles.append(dst)
         if f.basename == "xunit.console.dll":
@@ -176,49 +170,37 @@ def _xunit_library_test_impl(ctx):
     if xunit_console_dll == None:
         fail("xunit.console.dll not found in xunit runner files")
 
-    # Copy xunit.runner.json next to the test DLL to match MSBuild behavior.
+    # Symlink xunit.runner.json next to the test DLL to match MSBuild behavior.
     # Key settings: preEnumerateTheories=false avoids expensive upfront theory
     # enumeration, and diagnosticMessages=true enables long-running test warnings.
     xunit_runner_json = ctx.file._xunit_runner_config
     dst = ctx.actions.declare_file("%s/%s/%s" % (ctx.label.name, tfm, xunit_runner_json.basename))
-    ctx.actions.run_shell(
-        inputs = [xunit_runner_json],
-        outputs = [dst],
-        command = "cp -f \"$1\" \"$2\"",
-        arguments = [xunit_runner_json.path, dst.path],
-        mnemonic = "CopyFile",
-        progress_message = "Copying %s" % xunit_runner_json.basename,
-        use_default_shell_env = True,
-        execution_requirements = COPY_EXECUTION_REQUIREMENTS,
+    ctx.actions.symlink(
+        output = dst,
+        target_file = xunit_runner_json,
     )
     additional_runfiles.append(dst)
 
-    # Copy non-framework transitive runtime deps to the output directory.
+    # Symlink non-framework transitive runtime deps to the output directory.
     # Framework assemblies are already in the testhost via Core_Root, so only
-    # test helpers (TestUtilities, RemoteExecutor, etc.) need to be copied.
+    # test helpers (TestUtilities, RemoteExecutor, etc.) need to be symlinked.
     # Deduplicate by basename to avoid conflicts when NuGet packages provide
     # DLLs for multiple TFMs (e.g., net8.0 + netstandard2.0).
     framework_basenames = {f.basename: True for f in ctx.files._framework_assemblies}
-    copied_basenames = {}
+    symlinked_basenames = {}
     transitive_runtime_deps = runtime_provider.deps.to_list()
     for dep in transitive_runtime_deps:
         for lib in dep.libs:
-            if lib.extension == "dll" and lib.basename not in framework_basenames and lib.basename not in copied_basenames:
-                copied_basenames[lib.basename] = True
+            if lib.extension == "dll" and lib.basename not in framework_basenames and lib.basename not in symlinked_basenames:
+                symlinked_basenames[lib.basename] = True
                 dst = ctx.actions.declare_file("%s/%s/%s" % (ctx.label.name, tfm, lib.basename))
-                ctx.actions.run_shell(
-                    inputs = [lib],
-                    outputs = [dst],
-                    command = "cp -f \"$1\" \"$2\"",
-                    arguments = [lib.path, dst.path],
-                    mnemonic = "CopyFile",
-                    progress_message = "Copying files",
-                    use_default_shell_env = True,
-                    execution_requirements = COPY_EXECUTION_REQUIREMENTS,
+                ctx.actions.symlink(
+                    output = dst,
+                    target_file = lib,
                 )
                 additional_runfiles.append(dst)
 
-    # Copy data files to the output directory next to the test DLL.
+    # Symlink data files to the output directory next to the test DLL.
     # Preserves directory structure: for local files, paths are relative to
     # the package; for NuGet content files, the contentFiles/any/any/ prefix
     # is stripped to get the expected relative path.
@@ -242,15 +224,9 @@ def _xunit_library_test_impl(ctx):
             # Fallback: just use basename
             rel = f.basename
         dst = ctx.actions.declare_file("%s/%s/%s" % (ctx.label.name, tfm, rel))
-        ctx.actions.run_shell(
-            inputs = [f],
-            outputs = [dst],
-            command = "cp -f \"$1\" \"$2\" && chmod u+rw \"$2\"",
-            arguments = [f.path, dst.path],
-            mnemonic = "CopyFile",
-            progress_message = "Copying %s" % rel,
-            use_default_shell_env = True,
-            execution_requirements = COPY_EXECUTION_REQUIREMENTS,
+        ctx.actions.symlink(
+            output = dst,
+            target_file = f,
         )
         additional_runfiles.append(dst)
 
@@ -738,21 +714,15 @@ def _il_test_impl(ctx):
         executable = ctx.executable.ilasm_exe,
     )
 
-    # Copy runtime DLLs from deps alongside the test DLL
+    # Symlink runtime DLLs from deps alongside the test DLL
     for dep in ctx.attr.deps:
         runtime_info = dep[DotnetAssemblyRuntimeInfo]
         for lib in runtime_info.libs:
             if lib.extension == "dll":
                 dst = ctx.actions.declare_file(lib.basename, sibling = dll)
-                ctx.actions.run_shell(
-                    inputs = [lib],
-                    outputs = [dst],
-                    command = "cp -f \"$1\" \"$2\"",
-                    arguments = [lib.path, dst.path],
-                    mnemonic = "CopyFile",
-                    progress_message = "Copying %s" % lib.basename,
-                    use_default_shell_env = True,
-                    execution_requirements = COPY_EXECUTION_REQUIREMENTS,
+                ctx.actions.symlink(
+                    output = dst,
+                    target_file = lib,
                 )
                 additional_runfiles.append(dst)
 


### PR DESCRIPTION
Test directory construction was dependent on a lot of file copying, which wasn't cacheable. However, the output directories for managed tests don't need to rely on file copying, they should be able to use symlinks or even the deps.json.