### PR TITLE
Fix CopilotFixSync.cs: update for Copilot SDK API changes

### DIFF
--- a/src/tools/bazel/CopilotFixSync.cs
+++ b/src/tools/bazel/CopilotFixSync.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 // CopilotFixSync.cs
 //
 // Uses the GitHub Copilot SDK for .NET to automatically attempt BUILD.bazel
@@ -8,6 +11,8 @@
 // Requires:
 //   - GitHub.Copilot.SDK NuGet package
 //   - Copilot CLI installed and authenticated (COPILOT_GITHUB_TOKEN env var)
+
+#pragma warning disable CA2007 // Consider calling ConfigureAwait (not applicable to top-level scripts)
 
 #:package GitHub.Copilot.SDK@*
 
@@ -119,13 +124,7 @@ var prompt = $"""
     Only modify BUILD.bazel files. Do not modify any other files.
     """;
 
-await session.SendAsync(new UserMessageEvent
-{
-    Data = new UserMessageEventData
-    {
-        Content = prompt
-    }
-});
+await session.SendAsync(prompt);
 
 // Wait for the session to complete its work
 using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));


### PR DESCRIPTION
## Problem

The Copilot Auto-Fix job in the sync workflow fails to build:

```
error CS0246: The type or namespace name 'UserMessageEventData' could not be found
error IDE0073: A source file contains a header that does not match the required text
error CA2007: Consider calling ConfigureAwait on the awaited task
```

Seen in [workflow run #23077287893](https://github.com/agocke/runtime/actions/runs/23077287893/job/67040056793).

## Fix

- `SendAsync` now takes a string directly — `UserMessageEventData` was removed from the Copilot SDK
- Add .NET Foundation license header (required by IDE0073 analyzer)
- Suppress CA2007 (ConfigureAwait not applicable to top-level scripts)