### PR TITLE
Shield bazel tools from repo root build settings

### DIFF
--- a/src/tools/bazel/CopilotFixSync.cs
+++ b/src/tools/bazel/CopilotFixSync.cs
@@ -1,6 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 // CopilotFixSync.cs
 //
 // Uses the GitHub Copilot SDK for .NET to automatically attempt BUILD.bazel
@@ -11,8 +8,6 @@
 // Requires:
 //   - GitHub.Copilot.SDK NuGet package
 //   - Copilot CLI installed and authenticated (COPILOT_GITHUB_TOKEN env var)
-
-#pragma warning disable CA2007 // Consider calling ConfigureAwait (not applicable to top-level scripts)
 
 #:package GitHub.Copilot.SDK@*
 

--- a/src/tools/bazel/Directory.Build.props
+++ b/src/tools/bazel/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <!-- Shield bazel tools from the repo's root Directory.Build.props/targets.
+       These are standalone utilities that don't need the runtime repo's
+       strict analyzer configuration, Arcade SDK, versioning, or packaging.
+       Import only eng/Versions.props for package version variables. -->
+
+  <Import Project="$(MSBuildThisFileDirectory)../../../eng/Versions.props" />
+
+  <PropertyGroup>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/tools/bazel/Directory.Build.targets
+++ b/src/tools/bazel/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Empty: prevent root Directory.Build.targets from applying to bazel tools. -->
+</Project>


### PR DESCRIPTION
Replaces the per-file workarounds from #67 with a proper build boundary.

**`src/tools/bazel/Directory.Build.props`** — stops MSBuild from inheriting the repo root's `TreatWarningsAsErrors`, Arcade SDK, strict analyzers, `IDE0073` file header enforcement, etc. Only imports `eng/Versions.props` for package version variables.

**`src/tools/bazel/Directory.Build.targets`** — empty file to block the root targets (Arcade SDK imports, analyzer targets, etc.).

**`CopilotFixSync.cs`** — removes the license header and `#pragma warning disable CA2007` that are no longer needed.

All 6 subprojects verified to build cleanly with the shield in place.