### PR TITLE
Extract sync pipeline into testable scripts, fix Copilot auto-fix

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -183,10 +183,15 @@ jobs:
           chmod +x src/tools/bazel/sync-upstream.sh
           chmod +x src/tools/bazel/detect-upstream-changes.sh
 
-          # Generate the detection report
+          # Generate the detection report (exit 1 = build-changes, which is expected)
           git fetch origin bazel --quiet
           src/tools/bazel/detect-upstream-changes.sh origin/bazel HEAD \
-            --report-file /tmp/sync-report.md
+            --report-file /tmp/sync-report.md || true
+
+          if [ ! -f /tmp/sync-report.md ]; then
+            echo "ERROR: Detection script failed to produce a report"
+            exit 1
+          fi
 
           # Run the Copilot fix
           cd src/tools/bazel

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -19,16 +19,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  # ─── Job 1: Merge upstream and create PR ────────────────────────────────────
-  merge-and-pr:
-    name: Merge & Create PR
+  # ─── Job 1: Sync upstream commit ────────────────────────────────────────────
+  sync:
+    name: Sync Upstream
     runs-on: ubuntu-latest
     outputs:
-      pr_number: ${{ steps.create-pr.outputs.pr_number }}
-      sync_branch: ${{ steps.create-branch.outputs.branch }}
-      classification: ${{ steps.detect.outputs.classification }}
-      has_new_commits: ${{ steps.check-new.outputs.has_new_commits }}
-      report_file: ${{ steps.detect.outputs.report_file }}
+      pr_number: ${{ steps.run-sync.outputs.pr_number }}
+      sync_branch: ${{ steps.run-sync.outputs.sync_branch }}
+      classification: ${{ steps.run-sync.outputs.classification }}
+      has_new_commits: ${{ steps.run-sync.outputs.has_new_commits }}
     steps:
       - name: Checkout bazel branch
         uses: actions/checkout@v5
@@ -41,167 +40,45 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Add upstream remote and fetch
-        run: |
-          git remote add upstream https://github.com/dotnet/runtime.git || true
-          git fetch upstream release/10.0 --quiet
-
-      - name: Check for existing sync PR
-        id: check-existing
+      - name: Run sync script
+        id: run-sync
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          open_prs=$(gh pr list --repo "${{ github.repository }}" --base bazel --label bazel-sync --state open --json number --jq 'length')
-          if [ "$open_prs" -gt 0 ]; then
-            echo "has_open_pr=true" >> "$GITHUB_OUTPUT"
-            echo "An open sync PR already exists, skipping"
-          else
-            echo "has_open_pr=false" >> "$GITHUB_OUTPUT"
-          fi
+          chmod +x src/tools/bazel/sync-upstream.sh
+          # Capture outputs from the script
+          set +e
+          output=$(src/tools/bazel/sync-upstream.sh \
+            --repo "${{ github.repository }}" 2>&1)
+          exit_code=$?
+          set -e
 
-      - name: Check for new commits
-        id: check-new
-        if: steps.check-existing.outputs.has_open_pr == 'false'
-        run: |
-          # List unmerged upstream commits, oldest first
-          next_commit=$(git rev-list --reverse origin/bazel..upstream/release/10.0 | head -1)
-          if [ -z "$next_commit" ]; then
-            echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
-            echo "Already up-to-date"
-          else
+          echo "$output"
+
+          # Parse outputs from the script's summary
+          sync_branch=$(echo "$output" | grep '^ *Branch:' | awk '{print $2}')
+          classification=$(echo "$output" | grep '^ *Classification:' | awk '{print $2}')
+          pr_url=$(echo "$output" | grep '^ *PR:' | awk '{print $2}')
+          pr_number=$(echo "$pr_url" | grep -oP '/pull/\K[0-9]+' || true)
+
+          if [[ -n "$sync_branch" ]]; then
             echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
-            echo "next_commit=$next_commit" >> "$GITHUB_OUTPUT"
-            remaining=$(git rev-list --count origin/bazel..upstream/release/10.0)
-            echo "next_commit_subject=$(git log -1 --format='%s' "$next_commit")" >> "$GITHUB_OUTPUT"
-            echo "next_commit_short=$(git rev-parse --short "$next_commit")" >> "$GITHUB_OUTPUT"
-            echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
-            echo "Next commit: $next_commit (1 of $remaining pending)"
-          fi
-
-      - name: Create sync branch
-        id: create-branch
-        if: steps.check-new.outputs.has_new_commits == 'true'
-        run: |
-          short="${{ steps.check-new.outputs.next_commit_short }}"
-          branch="sync/release-10.0-${short}"
-          git checkout -b "$branch"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-
-      - name: Merge single upstream commit
-        id: merge
-        if: steps.check-new.outputs.has_new_commits == 'true'
-        run: |
-          next_commit="${{ steps.check-new.outputs.next_commit }}"
-          if git merge "$next_commit" --no-edit; then
-            echo "conflict=false" >> "$GITHUB_OUTPUT"
+            echo "sync_branch=$sync_branch" >> "$GITHUB_OUTPUT"
+            echo "classification=$classification" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::Merge conflicts detected"
-            echo "conflict=true" >> "$GITHUB_OUTPUT"
-            # Stage conflicted files so we can still create the PR
-            git add -A
-            git commit --no-edit -m "Merge $next_commit (with conflicts)" || true
+            echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run change detection
-        id: detect
-        if: steps.check-new.outputs.has_new_commits == 'true'
-        run: |
-          report_file="/tmp/sync-report.md"
-          next_commit="${{ steps.check-new.outputs.next_commit }}"
-
-          if [ "${{ steps.merge.outputs.conflict }}" = "true" ]; then
-            echo "classification=conflict" >> "$GITHUB_OUTPUT"
-            echo "# Sync Report" > "$report_file"
-            echo "" >> "$report_file"
-            echo "**Classification:** ❌ **conflict** — Merge conflicts need manual resolution" >> "$report_file"
-            echo "" >> "$report_file"
-            echo "## Conflicted Files" >> "$report_file"
-            git diff --name-only --diff-filter=U HEAD || true >> "$report_file"
-          else
-            chmod +x src/tools/bazel/detect-upstream-changes.sh
-            set +e
-            ./src/tools/bazel/detect-upstream-changes.sh origin/bazel "$next_commit" \
-              --report-file "$report_file"
-            exit_code=$?
-            set -e
-
-            if [ "$exit_code" -eq 0 ]; then
-              echo "classification=clean" >> "$GITHUB_OUTPUT"
-            elif [ "$exit_code" -eq 1 ]; then
-              echo "classification=build-changes" >> "$GITHUB_OUTPUT"
-            else
-              echo "classification=unknown" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-
-          echo "report_file=$report_file" >> "$GITHUB_OUTPUT"
-
-      - name: Push sync branch
-        if: steps.check-new.outputs.has_new_commits == 'true'
-        run: |
-          git push origin "${{ steps.create-branch.outputs.branch }}"
-
-      - name: Create PR
-        id: create-pr
-        if: steps.check-new.outputs.has_new_commits == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          classification="${{ steps.detect.outputs.classification }}"
-          report_file="${{ steps.detect.outputs.report_file }}"
-          commit_subject="${{ steps.check-new.outputs.next_commit_subject }}"
-          commit_short="${{ steps.check-new.outputs.next_commit_short }}"
-          remaining="${{ steps.check-new.outputs.remaining }}"
-
-          case "$classification" in
-            clean)
-              title="✅ Sync ${commit_short}: ${commit_subject}"
-              label_flags="--label bazel-sync --label bazel-sync-clean"
-              ;;
-            build-changes)
-              title="⚠️ Sync ${commit_short}: ${commit_subject}"
-              label_flags="--label bazel-sync --label bazel-sync-needs-attention"
-              ;;
-            conflict)
-              title="❌ Sync ${commit_short}: ${commit_subject}"
-              label_flags="--label bazel-sync --label bazel-sync-conflict"
-              ;;
-            *)
-              title="Sync ${commit_short}: ${commit_subject}"
-              label_flags="--label bazel-sync"
-              ;;
-          esac
-
-          # Prepend commit info to the report
-          commit_header="**Upstream commit:** [\`${commit_short}\`](https://github.com/dotnet/runtime/commit/${{ steps.check-new.outputs.next_commit }}) — ${commit_subject}"
-          commit_header+="\n**Remaining after this:** $((remaining - 1)) commit(s)\n\n---\n\n"
-          full_body=$(printf '%s' "$commit_header" && cat "$report_file")
-          echo "$full_body" > "$report_file"
-
-          pr_url=$(gh pr create \
-            --repo "${{ github.repository }}" \
-            --base bazel \
-            --head "${{ steps.create-branch.outputs.branch }}" \
-            --title "$title" \
-            --body-file "$report_file" \
-            $label_flags)
-
-          # Extract PR number from URL
-          pr_number=$(echo "$pr_url" | grep -oP '/pull/\K[0-9]+')
-          if [ -z "$pr_number" ]; then
-            echo "::error::Failed to extract PR number from: $pr_url"
-            exit 1
-          fi
-          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-          echo "Created PR: $pr_url"
+          exit "$exit_code"
 
   # ─── Job 2: Equivalence check ──────────────────────────────────────────────
   equivalence-check:
     name: Equivalence Check
-    needs: merge-and-pr
+    needs: sync
     if: >-
-      needs.merge-and-pr.outputs.has_new_commits == 'true' &&
-      needs.merge-and-pr.outputs.classification == 'build-changes' &&
+      needs.sync.outputs.has_new_commits == 'true' &&
+      needs.sync.outputs.classification == 'build-changes' &&
       github.event.inputs.skip_equivalence != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -210,7 +87,7 @@ jobs:
       - name: Checkout sync branch
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.merge-and-pr.outputs.sync_branch }}
+          ref: ${{ needs.sync.outputs.sync_branch }}
           fetch-depth: 0
 
       - name: Install dependencies
@@ -246,7 +123,7 @@ jobs:
           ./compare-bazel.sh --skip-build 2>&1 | tee /tmp/build-result.txt
 
       - name: Post results to PR
-        if: needs.merge-and-pr.outputs.pr_number != ''
+        if: needs.sync.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -265,16 +142,16 @@ jobs:
             comment+="<details><summary>Build Inputs Details</summary>\n\n\`\`\`\n$(tail -50 /tmp/build-result.txt)\n\`\`\`\n</details>\n"
           fi
 
-          echo -e "$comment" | gh pr comment "${{ needs.merge-and-pr.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file -
+          echo -e "$comment" | gh pr comment "${{ needs.sync.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file -
 
   # ─── Job 3: Copilot SDK auto-fix ───────────────────────────────────────────
   copilot-fix:
     name: Copilot Auto-Fix
-    needs: merge-and-pr
+    needs: sync
     if: >-
-      needs.merge-and-pr.outputs.has_new_commits == 'true' &&
-      (needs.merge-and-pr.outputs.classification == 'build-changes' ||
-       needs.merge-and-pr.outputs.classification == 'conflict') &&
+      needs.sync.outputs.has_new_commits == 'true' &&
+      (needs.sync.outputs.classification == 'build-changes' ||
+       needs.sync.outputs.classification == 'conflict') &&
       github.event.inputs.skip_copilot_fix != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -283,7 +160,8 @@ jobs:
       - name: Checkout sync branch
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.merge-and-pr.outputs.sync_branch }}
+          ref: ${{ needs.sync.outputs.sync_branch }}
+          fetch-depth: 0
 
       - name: Configure git
         run: |
@@ -298,17 +176,19 @@ jobs:
       - name: Install Copilot CLI
         run: npm install -g @github/copilot
 
-      - name: Regenerate detection report
-        run: |
-          git fetch origin bazel --quiet
-          chmod +x src/tools/bazel/detect-upstream-changes.sh
-          ./src/tools/bazel/detect-upstream-changes.sh origin/bazel HEAD \
-            --report-file /tmp/sync-report.md || true
-
-      - name: Run Copilot fix
+      - name: Run detection and Copilot fix
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
         run: |
+          chmod +x src/tools/bazel/sync-upstream.sh
+          chmod +x src/tools/bazel/detect-upstream-changes.sh
+
+          # Generate the detection report
+          git fetch origin bazel --quiet
+          src/tools/bazel/detect-upstream-changes.sh origin/bazel HEAD \
+            --report-file /tmp/sync-report.md
+
+          # Run the Copilot fix
           cd src/tools/bazel
           dotnet run CopilotFixSync.cs -- /tmp/sync-report.md
 
@@ -345,11 +225,11 @@ jobs:
           git push origin HEAD
 
       - name: Comment on PR (success)
-        if: steps.check-changes.outputs.has_changes == 'true' && steps.validate.outcome == 'success' && needs.merge-and-pr.outputs.pr_number != ''
+        if: steps.check-changes.outputs.has_changes == 'true' && steps.validate.outcome == 'success' && needs.sync.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment "${{ needs.merge-and-pr.outputs.pr_number }}" --repo "${{ github.repository }}" \
+          gh pr comment "${{ needs.sync.outputs.pr_number }}" --repo "${{ github.repository }}" \
             --body "🤖 **Copilot Auto-Fix Applied**
 
           Copilot SDK automatically updated BUILD.bazel files based on the detection report. Changes have been pushed to the sync branch and validated with \`bazel build //...\`.
@@ -360,7 +240,7 @@ jobs:
         if: >-
           (steps.check-changes.outputs.has_changes == 'false' ||
            steps.validate.outcome != 'success') &&
-          needs.merge-and-pr.outputs.pr_number != ''
+          needs.sync.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -369,7 +249,7 @@ jobs:
           else
             msg="🤖 **Copilot Auto-Fix Failed**: Changes were produced but \`bazel build\` validation failed. Manual intervention needed."
           fi
-          gh pr comment "${{ needs.merge-and-pr.outputs.pr_number }}" --repo "${{ github.repository }}" --body "$msg"
+          gh pr comment "${{ needs.sync.outputs.pr_number }}" --repo "${{ github.repository }}" --body "$msg"
 
       - name: Revert on validation failure
         if: steps.check-changes.outputs.has_changes == 'true' && steps.validate.outcome != 'success'

--- a/src/tools/bazel/CopilotFixSync.cs
+++ b/src/tools/bazel/CopilotFixSync.cs
@@ -35,7 +35,8 @@ await client.StartAsync();
 
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "claude-sonnet-4"
+    Model = "claude-sonnet-4",
+    OnPermissionRequest = PermissionHandler.ApproveAll
 });
 
 var prompt = $"""

--- a/src/tools/bazel/CopilotFixSync.cs
+++ b/src/tools/bazel/CopilotFixSync.cs
@@ -40,10 +40,12 @@ await using var session = await client.CreateSessionAsync(new SessionConfig
 });
 
 var prompt = $"""
-    You are updating Bazel BUILD files for the dotnet/runtime repository after
+    You are updating Bazel build files for the dotnet/runtime repository after
     merging upstream changes from release/10.0 into the bazel branch.
 
-    ## Context: How BUILD.bazel files work in this repository
+    ## Context: How Bazel build files work in this repository
+
+    ### Source files in BUILD.bazel
 
     Libraries under src/libraries/ have BUILD.bazel files that define Bazel build
     targets. The key patterns are:
@@ -72,18 +74,61 @@ var prompt = $"""
 
     5. **Defines**: `<DefineConstants>` in .csproj → `defines` list in BUILD.bazel
 
+    ### NuGet package versions (CRITICAL)
+
+    Some NuGet packages are referenced with **version-pinned labels** that embed
+    the exact version string. These appear across BUILD.bazel, MODULE.bazel,
+    paket/paket.main.bzl, and src/libraries/defs.bzl files. The pattern is:
+
+        @nuget.<lowercased.package.name>.v<version>//:path/to/file.dll
+
+    For example:
+    - `@nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102//:tools/snk/MSFT.snk`
+    - `@nuget.microsoft.dotnet.genfacades.v10.0.0-beta.26102.102//:tools/net/Microsoft.DotNet.GenFacades.dll`
+    - `@nuget.microsoft.dotnet.xunitconsolerunner.v2.9.3-beta.26102.102//:tools/net/xunit.console.dll`
+
+    When upstream bumps a package version, ALL references to the old versioned
+    label must be updated to the new version. This is a simple text replacement
+    of the version string within these labels. The files that contain versioned
+    NuGet labels are:
+
+    - `MODULE.bazel` — `use_repo(...)` declarations
+    - `paket/paket.main.bzl` — NuGet package declarations (name, version, sha512).
+      **Important**: Only update the `"version"` field. Do NOT change the `"sha512"`
+      field — it will be updated separately by tooling.
+    - `eng/BUILD.bazel` — xunit console runner references
+    - `src/libraries/defs.bzl` — default signing key references
+    - `src/libraries/BUILD.bazel` — signing key references
+    - `src/coreclr/System.Private.CoreLib/BUILD.bazel` — signing key references
+    - `src/tools/bazel/GenFacades/BUILD.bazel` — GenFacades tool DLL references
+    - `src/tools/bazel/GenNotSupportedSource/BUILD.bazel` — GenFacades tool DLL references
+    - `src/tools/bazel/GenerateResxSource/BUILD.bazel` — Arcade SDK tool references
+
+    **Example**: If `eng/Version.Details.props` bumps `MicrosoftDotNetArcadeSdkPackageVersion`
+    from `10.0.0-beta.26102.102` to `10.0.0-beta.26110.124`, then every occurrence of
+    `nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26102.102` must be replaced with
+    `nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26110.124` across all the files above.
+
+    Note: not all packages use versioned labels. Most test dependencies use
+    unversioned `@paket.main//package.name` references which resolve automatically
+    and don't need updating.
+
     ## Detection Report
 
     {detectionReport}
 
     ## Instructions
 
-    Based on the detection report above, make the necessary changes to BUILD.bazel
-    files. For each item flagged as needing a BUILD.bazel update:
+    Based on the detection report above, make the necessary changes to Bazel build
+    files. For each item flagged as needing an update:
+
+    - **Version bump affects Bazel NuGet deps**: This is the most common case.
+      Find every occurrence of the old versioned label and replace the version
+      string with the new one. Check all `.bazel` and `.bzl` files listed above.
+      The old and new versions can be read from the diff in the detection report.
 
     - **New .cs files (explicit srcs)**: Add the file path to the `srcs` list in
-      the appropriate BUILD.bazel file. Use the relative path from the library root
-      (e.g., "src/System/Foo.cs"). Maintain alphabetical ordering within the list.
+      the appropriate BUILD.bazel file. Maintain alphabetical ordering.
 
     - **Removed .cs files (explicit srcs)**: Remove the file path from the `srcs`
       list in the appropriate BUILD.bazel file.
@@ -95,10 +140,8 @@ var prompt = $"""
 
     - **New .resx files**: Add a `resx_file` parameter if not already present.
 
-    If no BUILD.bazel changes are needed (e.g., all changes are in glob-based
-    libraries or are version-only bumps), make no changes and explain why.
-
-    Only modify BUILD.bazel files. Do not modify any other files.
+    You may modify: BUILD.bazel, MODULE.bazel, paket/paket.main.bzl, and
+    src/libraries/defs.bzl files. Do not modify any other file types.
     """;
 
 try

--- a/src/tools/bazel/detect-upstream-changes.sh
+++ b/src/tools/bazel/detect-upstream-changes.sh
@@ -233,28 +233,27 @@ if [[ -n "$changed_props" ]]; then
                     | sort -u || true)
 
                 if [[ -n "$changed_pkg_names" ]]; then
-                    # Build a list of NuGet package names used by Bazel (dotted form)
-                    bazel_pkgs=""
+                    # Build a lookup file of NuGet package names used by Bazel,
+                    # with dots stripped and lowercased for matching against
+                    # MSBuild property names (e.g. "microsoftdotnetarcadesdk").
+                    paket_lookup_file=$(mktemp)
                     if [[ -f "paket/paket.main.bzl" ]]; then
-                        bazel_pkgs=$(grep -oP '"name":\s*"\K[^"]+' paket/paket.main.bzl 2>/dev/null || true)
+                        grep -oP '"name":\s*"\K[^"]+' paket/paket.main.bzl 2>/dev/null \
+                            | while IFS= read -r name; do
+                                stripped=$(echo "$name" | tr -d '.' | tr '[:upper:]' '[:lower:]')
+                                echo "$stripped $name"
+                            done > "$paket_lookup_file"
                     fi
 
                     while IFS= read -r pkg; do
                         [[ -z "$pkg" ]] && continue
-                        # Match by stripping dots from NuGet names and comparing
-                        # case-insensitively against the MSBuild property prefix.
-                        # e.g. property "MicrosoftDotNetArcadeSdk" matches
-                        #      NuGet name "Microsoft.DotNet.Arcade.Sdk"
                         pkg_lower=$(echo "$pkg" | tr '[:upper:]' '[:lower:]')
-                        while IFS= read -r nuget_name; do
-                            [[ -z "$nuget_name" ]] && continue
-                            stripped=$(echo "$nuget_name" | tr -d '.' | tr '[:upper:]' '[:lower:]')
-                            if [[ "$stripped" == "$pkg_lower" ]]; then
-                                bazel_affected+="$nuget_name "
-                                break
-                            fi
-                        done <<< "$bazel_pkgs"
+                        match=$(grep "^${pkg_lower} " "$paket_lookup_file" | head -1 | cut -d' ' -f2 || true)
+                        if [[ -n "$match" ]]; then
+                            bazel_affected+="$match "
+                        fi
                     done <<< "$changed_pkg_names"
+                    rm -f "$paket_lookup_file"
                 fi
 
                 if [[ -n "$bazel_affected" ]]; then

--- a/src/tools/bazel/sync-upstream.sh
+++ b/src/tools/bazel/sync-upstream.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# sync-upstream.sh
+#
+# Syncs the next upstream commit from release/10.0 into the bazel branch.
+# Runs the full pipeline: check → merge → detect → push → create PR.
+#
+# This script is the single source of truth for the sync logic.
+# The GitHub Actions workflow is a thin wrapper that calls this script.
+#
+# Usage:
+#   ./src/tools/bazel/sync-upstream.sh [options]
+#
+# Options:
+#   --repo OWNER/REPO   GitHub repository (default: auto-detect from git remote)
+#   --upstream-ref REF  Upstream branch to sync from (default: release/10.0)
+#   --base-branch NAME  Local base branch (default: bazel)
+#   --dry-run           Do everything except push and create PR
+#   --detect-only       Only run change detection on existing HEAD vs base
+#   --skip-push         Skip git push (but still create branch and merge)
+#   --skip-pr           Skip PR creation (but still push)
+#   --copilot-fix       Run Copilot auto-fix if build-changes detected
+#   -v, --verbose       Print commands as they execute
+#   -h, --help          Show this help
+#
+# Prerequisites:
+#   - git with fetch access to upstream
+#   - gh CLI (authenticated) for PR operations
+#
+# Exit codes:
+#   0 = success (PR created, or up-to-date, or dry-run completed)
+#   1 = failure
+#   2 = usage error
+
+set -euo pipefail
+
+# ─── Defaults ─────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+REPO=""
+UPSTREAM_REF="release/10.0"
+BASE_BRANCH="bazel"
+DRY_RUN=false
+DETECT_ONLY=false
+SKIP_PUSH=false
+SKIP_PR=false
+COPILOT_FIX=false
+VERBOSE=false
+
+# ─── Parse arguments ─────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)          REPO="$2"; shift 2 ;;
+        --upstream-ref)  UPSTREAM_REF="$2"; shift 2 ;;
+        --base-branch)   BASE_BRANCH="$2"; shift 2 ;;
+        --dry-run)       DRY_RUN=true; shift ;;
+        --detect-only)   DETECT_ONLY=true; shift ;;
+        --skip-push)     SKIP_PUSH=true; shift ;;
+        --skip-pr)       SKIP_PR=true; shift ;;
+        --copilot-fix)   COPILOT_FIX=true; shift ;;
+        -v|--verbose)    VERBOSE=true; shift ;;
+        -h|--help)
+            sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ "$VERBOSE" == true ]]; then
+    set -x
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+    SKIP_PUSH=true
+    SKIP_PR=true
+fi
+
+cd "$REPO_ROOT"
+
+# Auto-detect repo from git remote if not specified
+if [[ -z "$REPO" ]]; then
+    REPO=$(git remote get-url origin 2>/dev/null \
+        | sed -n 's|.*github\.com[:/]\([^/]*/[^/.]*\).*|\1|p')
+    if [[ -z "$REPO" ]]; then
+        echo "Error: could not detect repository. Use --repo OWNER/REPO." >&2
+        exit 2
+    fi
+fi
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+info()  { echo "==> $*"; }
+detail() { echo "    $*"; }
+err()   { echo "ERROR: $*" >&2; }
+
+# ─── Detect-only mode ────────────────────────────────────────────────────────
+
+if [[ "$DETECT_ONLY" == true ]]; then
+    info "Running change detection only"
+    report_file="/tmp/sync-report.md"
+    detect_exit=0
+    "$SCRIPT_DIR/detect-upstream-changes.sh" "origin/$BASE_BRANCH" HEAD \
+        --report-file "$report_file" || detect_exit=$?
+
+    if [[ ! -f "$report_file" ]]; then
+        err "Detection script failed (exit $detect_exit) and produced no report."
+        exit 1
+    fi
+
+    cat "$report_file"
+    exit "$detect_exit"
+fi
+
+# ─── Step 1: Check for existing sync PR ──────────────────────────────────────
+
+info "Checking for existing sync PRs..."
+
+open_prs=$(gh pr list --repo "$REPO" --base "$BASE_BRANCH" \
+    --label bazel-sync --state open --json number --jq 'length' 2>/dev/null || echo "0")
+
+if [[ "$open_prs" -gt 0 ]]; then
+    info "An open sync PR already exists. Close or merge it first."
+    exit 0
+fi
+
+# ─── Step 2: Fetch upstream and find next commit ─────────────────────────────
+
+info "Fetching upstream..."
+
+git remote add upstream https://github.com/dotnet/runtime.git 2>/dev/null || true
+git fetch upstream "$UPSTREAM_REF" --quiet
+git fetch origin "$BASE_BRANCH" --quiet
+
+next_commit=$(git rev-list --reverse "origin/$BASE_BRANCH..upstream/$UPSTREAM_REF" | head -1)
+
+if [[ -z "$next_commit" ]]; then
+    info "Already up-to-date with upstream/$UPSTREAM_REF."
+    exit 0
+fi
+
+remaining=$(git rev-list --count "origin/$BASE_BRANCH..upstream/$UPSTREAM_REF")
+commit_short=$(git rev-parse --short "$next_commit")
+commit_subject=$(git log -1 --format='%s' "$next_commit")
+
+info "Next commit: $commit_short — $commit_subject"
+detail "($remaining commit(s) pending)"
+
+# ─── Step 3: Create sync branch and merge ────────────────────────────────────
+
+branch="sync/${UPSTREAM_REF//\//-}-${commit_short}"
+
+info "Creating branch: $branch"
+git checkout -B "$branch" "origin/$BASE_BRANCH" --quiet
+
+conflict=false
+if git merge "$next_commit" --no-edit 2>/dev/null; then
+    detail "Merge succeeded (no conflicts)"
+else
+    detail "Merge conflicts detected"
+    conflict=true
+    git add -A
+    git commit --no-edit -m "Merge $next_commit (with conflicts)" 2>/dev/null || true
+fi
+
+# ─── Step 4: Run change detection ────────────────────────────────────────────
+
+info "Running change detection..."
+
+report_file="/tmp/sync-report.md"
+classification="unknown"
+
+if [[ "$conflict" == true ]]; then
+    classification="conflict"
+    cat > "$report_file" <<CONFLICT_EOF
+# Sync Report: \`$UPSTREAM_REF\` → \`$BASE_BRANCH\`
+
+**Classification:** ❌ **conflict** — Merge conflicts need manual resolution
+
+## Conflicted Files
+$(git diff --name-only --diff-filter=U HEAD 2>/dev/null || true)
+CONFLICT_EOF
+else
+    detect_exit=0
+    "$SCRIPT_DIR/detect-upstream-changes.sh" "origin/$BASE_BRANCH" "$next_commit" \
+        --report-file "$report_file" || detect_exit=$?
+
+    if [[ ! -f "$report_file" ]]; then
+        err "Detection script failed (exit $detect_exit) and produced no report."
+        exit 1
+    fi
+
+    case "$detect_exit" in
+        0) classification="clean" ;;
+        1) classification="build-changes" ;;
+    esac
+fi
+
+detail "Classification: $classification"
+echo ""
+cat "$report_file"
+echo ""
+
+# ─── Step 5: Push branch ─────────────────────────────────────────────────────
+
+if [[ "$SKIP_PUSH" == true ]]; then
+    info "Push skipped (--dry-run or --skip-push)"
+else
+    info "Pushing $branch..."
+    git push origin "$branch"
+fi
+
+# ─── Step 6: Create PR ───────────────────────────────────────────────────────
+
+if [[ "$SKIP_PR" == true ]]; then
+    info "PR creation skipped (--dry-run or --skip-pr)"
+else
+    info "Creating PR..."
+
+    case "$classification" in
+        clean)
+            title="✅ Sync ${commit_short}: ${commit_subject}"
+            label_flags="--label bazel-sync --label bazel-sync-clean"
+            ;;
+        build-changes)
+            title="⚠️ Sync ${commit_short}: ${commit_subject}"
+            label_flags="--label bazel-sync --label bazel-sync-needs-attention"
+            ;;
+        conflict)
+            title="❌ Sync ${commit_short}: ${commit_subject}"
+            label_flags="--label bazel-sync --label bazel-sync-conflict"
+            ;;
+        *)
+            title="Sync ${commit_short}: ${commit_subject}"
+            label_flags="--label bazel-sync"
+            ;;
+    esac
+
+    # Prepend commit info header
+    header="**Upstream commit:** [\`${commit_short}\`](https://github.com/dotnet/runtime/commit/${next_commit}) — ${commit_subject}"
+    header+="\n**Remaining after this:** $((remaining - 1)) commit(s)\n\n---\n\n"
+    full_body=$(printf '%s' "$header" && cat "$report_file")
+    echo "$full_body" > "$report_file"
+
+    # shellcheck disable=SC2086
+    pr_url=$(gh pr create \
+        --repo "$REPO" \
+        --base "$BASE_BRANCH" \
+        --head "$branch" \
+        --title "$title" \
+        --body-file "$report_file" \
+        $label_flags)
+
+    pr_number=$(echo "$pr_url" | grep -oP '/pull/\K[0-9]+')
+    if [[ -z "$pr_number" ]]; then
+        err "Failed to extract PR number from: $pr_url"
+        exit 1
+    fi
+
+    detail "Created: $pr_url"
+fi
+
+# ─── Step 7: Copilot auto-fix (optional) ─────────────────────────────────────
+
+if [[ "$COPILOT_FIX" == true && ("$classification" == "build-changes" || "$classification" == "conflict") ]]; then
+    info "Running Copilot auto-fix..."
+
+    if ! command -v copilot &>/dev/null; then
+        err "Copilot CLI not found. Install with: npm install -g @github/copilot"
+        err "Skipping auto-fix."
+    elif [[ ! -f "$report_file" ]]; then
+        err "No report file — skipping auto-fix."
+    else
+        cd "$SCRIPT_DIR"
+        if dotnet run CopilotFixSync.cs -- "$report_file"; then
+            cd "$REPO_ROOT"
+            if ! git diff --quiet; then
+                detail "Copilot produced changes:"
+                git diff --stat
+                if [[ "$SKIP_PUSH" != true ]]; then
+                    git add -A
+                    git commit -m "Auto-fix BUILD.bazel files for upstream sync
+
+Applied by Copilot SDK based on detection report.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+                    git push origin HEAD
+                    detail "Pushed auto-fix commit."
+                fi
+            else
+                detail "Copilot produced no changes."
+            fi
+        else
+            err "CopilotFixSync.cs failed."
+        fi
+        cd "$REPO_ROOT"
+    fi
+fi
+
+# ─── Done ─────────────────────────────────────────────────────────────────────
+
+info "Done."
+echo ""
+echo "  Branch:          $branch"
+echo "  Classification:  $classification"
+echo "  Remaining:       $((remaining - 1)) commit(s)"
+if [[ -n "${pr_url:-}" ]]; then
+    echo "  PR:              $pr_url"
+fi


### PR DESCRIPTION
## Summary

Extracts the sync workflow from 380 lines of inline YAML bash into a standalone script that can be tested locally, and fixes the Copilot auto-fix pipeline end-to-end.

## Changes

### `src/tools/bazel/sync-upstream.sh` (new)
Full sync pipeline as a standalone script:
```bash
./src/tools/bazel/sync-upstream.sh --dry-run          # local test, no push/PR
./src/tools/bazel/sync-upstream.sh --detect-only      # just run detection on current branch
./src/tools/bazel/sync-upstream.sh --repo owner/repo  # full run
```

### `src/tools/bazel/detect-upstream-changes.sh`
Fixed O(n×m) nested loop that spawned shell subprocesses for every changed package × every entry in 92KB paket.main.bzl. Now uses a temp lookup file + grep. ~3 min on CI → <1s.

### `src/tools/bazel/CopilotFixSync.cs`
- Added `OnPermissionRequest = PermissionHandler.ApproveAll` (SDK requirement)
- Rewrote prompt to handle NuGet version bumps — the most common sync scenario. Old prompt told the LLM to skip version bumps and only modify BUILD.bazel files. New prompt explains version-pinned labels (`@nuget.<pkg>.v<ver>`), lists all affected files, gives concrete examples.

### `.github/workflows/sync-release.yml`
- Job 1: thin wrapper calling `sync-upstream.sh`
- Copilot job: handles detection exit code 1 (build-changes) without dying

## Local test results

```
$ ./src/tools/bazel/sync-upstream.sh --skip-push --skip-pr
==> Next commit: 066be76ee5d — [release/10.0] Source code updates
    Classification: build-changes
    ⚠️ version bump affects Bazel NuGet deps: Microsoft.DotNet.Arcade.Sdk ...

$ dotnet run CopilotFixSync.cs -- /tmp/sync-report.md
  → Updated 142 files (BUILD.bazel, MODULE.bazel, paket.main.bzl, defs.bzl)
  → Zero old version refs remaining, sha512 hashes preserved
```