### PR TITLE
Fix SIGPIPE (exit 141) in sync-upstream.sh

### DIFF
--- a/src/tools/bazel/sync-upstream.sh
+++ b/src/tools/bazel/sync-upstream.sh
@@ -138,14 +138,15 @@ git remote add upstream https://github.com/dotnet/runtime.git 2>/dev/null || tru
 git fetch upstream "$UPSTREAM_REF" --quiet
 git fetch origin "$BASE_BRANCH" --quiet
 
-next_commit=$(git rev-list --reverse "origin/$BASE_BRANCH..upstream/$UPSTREAM_REF" | head -1)
+all_commits=$(git rev-list --reverse "origin/$BASE_BRANCH..upstream/$UPSTREAM_REF")
+next_commit=$(head -1 <<< "$all_commits")
 
 if [[ -z "$next_commit" ]]; then
     info "Already up-to-date with upstream/$UPSTREAM_REF."
     exit 0
 fi
 
-remaining=$(git rev-list --count "origin/$BASE_BRANCH..upstream/$UPSTREAM_REF")
+remaining=$(wc -l <<< "$all_commits" | tr -d ' ')
 commit_short=$(git rev-parse --short "$next_commit")
 commit_subject=$(git log -1 --format='%s' "$next_commit")
 


### PR DESCRIPTION
Under `set -euo pipefail`, `git rev-list | head -1` causes SIGPIPE when `head` closes the pipe before git finishes writing. Exit code 141 = 128 + 13 (SIGPIPE).

Fix: capture full rev-list output into a variable, then use here-strings (`<<<`) instead of echo-pipe to extract the first line and count.

Verified with:
```bash
# Old pattern fails:
bash -c 'set -euo pipefail; seq 100000 | head -1'  # exit 141

# Here-string works:
bash -c 'set -euo pipefail; all=$(seq 100000); head -1 <<< "$all"'  # exit 0
```