### PR TITLE
Fix GitHub Actions output parsing in sync workflow

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -56,9 +56,9 @@ jobs:
           echo "$output"
 
           # Parse outputs from the script's summary
-          sync_branch=$(echo "$output" | grep '^ *Branch:' | awk '{print $2}')
-          classification=$(echo "$output" | grep '^ *Classification:' | awk '{print $2}')
-          pr_url=$(echo "$output" | grep '^ *PR:' | awk '{print $2}')
+          sync_branch=$(echo "$output" | grep '^ *Branch:' | awk '{print $2}' | tr -d '\r')
+          classification=$(echo "$output" | grep '^ *Classification:' | awk '{print $2}' | tr -d '\r')
+          pr_url=$(echo "$output" | grep '^ *PR:' | awk '{print $2}' | tr -d '\r')
           pr_number=$(echo "$pr_url" | grep -oP '/pull/\K[0-9]+' || true)
 
           if [[ -n "$sync_branch" ]]; then

--- a/src/tools/bazel/sync-upstream.sh
+++ b/src/tools/bazel/sync-upstream.sh
@@ -138,14 +138,15 @@ git remote add upstream https://github.com/dotnet/runtime.git 2>/dev/null || tru
 git fetch upstream "$UPSTREAM_REF" --quiet
 git fetch origin "$BASE_BRANCH" --quiet
 
-next_commit=$(git rev-list --reverse "origin/$BASE_BRANCH..upstream/$UPSTREAM_REF" | head -1)
+all_commits=$(git rev-list --reverse "origin/$BASE_BRANCH..upstream/$UPSTREAM_REF")
+next_commit=$(head -1 <<< "$all_commits")
 
 if [[ -z "$next_commit" ]]; then
     info "Already up-to-date with upstream/$UPSTREAM_REF."
     exit 0
 fi
 
-remaining=$(git rev-list --count "origin/$BASE_BRANCH..upstream/$UPSTREAM_REF")
+remaining=$(wc -l <<< "$all_commits" | tr -d ' ')
 commit_short=$(git rev-parse --short "$next_commit")
 commit_subject=$(git log -1 --format='%s' "$next_commit")
 


### PR DESCRIPTION
The sync script output may contain \r\n line endings, causing values like `classification=build-changes\r` to be written to `$GITHUB_OUTPUT`. GitHub Actions rejects this as `Invalid format 'build-changes'`.

Fix: add `tr -d '\r'` when parsing Branch, Classification, and PR fields from script output.