### PR TITLE
Fix sync workflow: add paket install and BUILD.bazel version scanning

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -57,6 +57,9 @@ jobs:
         if: github.event.inputs.skip_copilot_fix != 'true'
         run: npm install -g @github/copilot
 
+      - name: Install Paket
+        run: dotnet tool install -g paket
+
       - name: Run sync
         id: run-sync
         env:

--- a/src/tools/bazel/FixVersionBumps.cs
+++ b/src/tools/bazel/FixVersionBumps.cs
@@ -235,6 +235,86 @@ if (File.Exists(modulePath))
 }
 
 Console.WriteLine("\nDone. Run sync-paket.sh to regenerate paket/paket.main.bzl.");
+
+// ─── Step 6: Scan BUILD.bazel and .bzl files for hardcoded versioned repo names ──
+
+Console.WriteLine("\nScanning BUILD.bazel files for hardcoded versioned repo names...");
+var buildFiles = Directory.EnumerateFiles(repoRoot, "BUILD.bazel", SearchOption.AllDirectories)
+    .Where(f => !f.Contains("paket/paket.main"))
+    .ToList();
+
+var totalBuildReplacements = 0;
+
+foreach (var buildFile in buildFiles)
+{
+    var content = File.ReadAllText(buildFile);
+    var updated = false;
+
+    foreach (var (packageName, oldVersion, newVersion) in replacements)
+    {
+        var lowerName = packageName.ToLowerInvariant();
+        var oldRepoName = $"nuget.{lowerName}.v{oldVersion}";
+        var newRepoName = $"nuget.{lowerName}.v{newVersion}";
+
+        if (content.Contains(oldRepoName))
+        {
+            var count = CountOccurrences(content, oldRepoName);
+            content = content.Replace(oldRepoName, newRepoName);
+            var relativePath = Path.GetRelativePath(repoRoot, buildFile);
+            Console.WriteLine($"  {relativePath}: {count} replacement(s) ({oldRepoName})");
+            totalBuildReplacements += count;
+            updated = true;
+        }
+    }
+
+    if (updated)
+        File.WriteAllText(buildFile, content);
+}
+
+if (totalBuildReplacements == 0)
+    Console.WriteLine("  No hardcoded versioned repo names found in BUILD.bazel files.");
+else
+    Console.WriteLine($"\n{totalBuildReplacements} total replacement(s) in BUILD.bazel files.");
+
+Console.WriteLine("\nScanning .bzl files for hardcoded versioned repo names...");
+var bzlFiles = Directory.EnumerateFiles(repoRoot, "*.bzl", SearchOption.AllDirectories)
+    .Where(f => !f.Contains("paket/paket.main"))
+    .ToList();
+
+var totalBzlReplacements = 0;
+
+foreach (var bzlFile in bzlFiles)
+{
+    var content = File.ReadAllText(bzlFile);
+    var updated = false;
+
+    foreach (var (packageName, oldVersion, newVersion) in replacements)
+    {
+        var lowerName = packageName.ToLowerInvariant();
+        var oldRepoName = $"nuget.{lowerName}.v{oldVersion}";
+        var newRepoName = $"nuget.{lowerName}.v{newVersion}";
+
+        if (content.Contains(oldRepoName))
+        {
+            var count = CountOccurrences(content, oldRepoName);
+            content = content.Replace(oldRepoName, newRepoName);
+            var relativePath = Path.GetRelativePath(repoRoot, bzlFile);
+            Console.WriteLine($"  {relativePath}: {count} replacement(s) ({oldRepoName})");
+            totalBzlReplacements += count;
+            updated = true;
+        }
+    }
+
+    if (updated)
+        File.WriteAllText(bzlFile, content);
+}
+
+if (totalBzlReplacements == 0)
+    Console.WriteLine("  No hardcoded versioned repo names found in .bzl files.");
+else
+    Console.WriteLine($"\n{totalBzlReplacements} total replacement(s) in .bzl files.");
+
+Console.WriteLine("\nDone. Run paket install then sync-paket.sh to regenerate paket files.");
 return 0;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/src/tools/bazel/sync-upstream.sh
+++ b/src/tools/bazel/sync-upstream.sh
@@ -30,7 +30,8 @@
 #   3. Create sync branch, merge
 #   4. Run change detection
 #   5. Fix version bumps (deterministic — no Copilot needed)
-#      - Updates paket.dependencies, defs.bzl, MODULE.bazel
+#      - Updates paket.dependencies, defs.bzl, MODULE.bazel, BUILD.bazel files
+#      - Runs paket install to regenerate paket.lock
 #      - Runs sync-paket.sh to regenerate paket/paket.main.bzl
 #   6. Run Copilot auto-fix (if --copilot-fix and non-version build-changes)
 #   7. Push branch
@@ -255,7 +256,27 @@ if [[ "$classification" == "build-changes" || "$classification" == "conflict" ]]
         if ! git diff --quiet; then
             detail "Version bump changes detected — regenerating paket files..."
 
-            # Regenerate paket/paket.main.bzl from updated paket.dependencies
+            # Regenerate paket.lock from updated paket.dependencies
+            if command -v paket &>/dev/null; then
+                info "Running paket install to regenerate paket.lock..."
+                if paket install; then
+                    detail "paket.lock regenerated successfully."
+                else
+                    err "paket install failed — paket.lock may be stale."
+                fi
+            elif dotnet tool list -g 2>/dev/null | grep -qi paket; then
+                info "Running dotnet paket install to regenerate paket.lock..."
+                if dotnet paket install; then
+                    detail "paket.lock regenerated successfully."
+                else
+                    err "dotnet paket install failed — paket.lock may be stale."
+                fi
+            else
+                err "paket not found — skipping paket.lock regeneration."
+                err "Install paket: dotnet tool install -g paket"
+            fi
+
+            # Regenerate paket/paket.main.bzl from updated paket.lock
             if command -v bazel &>/dev/null || command -v bazelisk &>/dev/null; then
                 info "Running sync-paket.sh to regenerate paket/paket.main.bzl..."
                 if "$REPO_ROOT/sync-paket.sh"; then


### PR DESCRIPTION
Three fixes to prevent version bump sync failures:

1. **sync-upstream.sh**: Add `paket install` step before `sync-paket.sh` to regenerate `paket.lock` when `paket.dependencies` is updated. Without this, `paket2bazel` generates repos from stale lock file versions, causing Bazel analysis errors like:
   ```
   module extension does not generate repository "nuget.microsoft.dotnet.arcade.sdk.v10.0.0-beta.26110.124"
   ```

2. **FixVersionBumps.cs**: Add Step 6 to scan all BUILD.bazel and .bzl files for hardcoded versioned NuGet repo names and update them (catches refs not covered by defs.bzl constants).

3. **sync-release.yml**: Install paket tool (`dotnet tool install -g paket`) in CI.

### Testing

Ran full dry-run of `sync-upstream.sh` with the same upstream commit (066be76ee5d) that broke PR #86:
- ✅ FixVersionBumps.cs detected 9 Bazel-relevant package bumps
- ✅ `paket install` regenerated paket.lock (7 packages updated)
- ✅ `sync-paket.sh` regenerated paket/paket.main.bzl
- ✅ Step 6 found and updated 14 hardcoded version refs in 3 BUILD.bazel files
- ✅ Sync completed successfully with correct commit