### PR TITLE
Fix paket install: add nuget.org source

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm install -g @github/copilot
 
       - name: Install Paket
-        run: dotnet tool install -g paket
+        run: dotnet tool install -g paket --add-source https://api.nuget.org/v3/index.json
 
       - name: Run sync
         id: run-sync


### PR DESCRIPTION
The repo's `NuGet.config` overrides default package sources with Azure DevOps feeds that don't carry the paket tool. Adds `--add-source https://api.nuget.org/v3/index.json` to the `dotnet tool install` command.