### PR TITLE
Copy SNK files to stable paths to improve cache hit rate

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -18,12 +18,15 @@ jobs:
           - os: ubuntu-latest
             name: Linux checked
             config: clr_checked
+            libs_config: libs_release
           - os: macos-latest
             name: macOS release
             config: clr_release
+            libs_config: libs_release
           - os: windows-latest
             name: Windows host
             config: clr_release
+            libs_config: libs_release
             targets: //src/native/corehost:all
 
     name: ${{ matrix.name }}
@@ -53,11 +56,11 @@ jobs:
             bazel-${{ runner.os }}-${{ matrix.config }}-
 
       - name: Build
-        run: bazel build ${{ matrix.targets || '//...' }} --config=${{ matrix.config }} --disk_cache=~/.cache/bazel-disk
+        run: bazel build ${{ matrix.targets || '//...' }} --config=${{ matrix.config }} ${{ matrix.libs_config && format('--config={0}', matrix.libs_config) || '' }} --disk_cache=~/.cache/bazel-disk
 
       - name: Test
         if: ${{ !matrix.targets }}
-        run: bazel test //... --config=${{ matrix.config }} --disk_cache=~/.cache/bazel-disk --test_output=errors
+        run: bazel test //... --config=${{ matrix.config }} ${{ matrix.libs_config && format('--config={0}', matrix.libs_config) || '' }} --disk_cache=~/.cache/bazel-disk --test_output=errors
 
       - name: Save Bazel cache
         if: github.event_name == 'push'

--- a/defs.bzl
+++ b/defs.bzl
@@ -25,12 +25,15 @@ MIBC_LINUX_X64_REPO = "nuget.optimization.linux-x64.mibc.runtime.v1.0.0-prerelea
 MIBC_LINUX_ARM64_REPO = "nuget.optimization.linux-arm64.mibc.runtime.v1.0.0-prerelease.26080.1"
 
 # ─── Pre-built labels for commonly used assets ───────────────────────────────
+# SNK signing keys are copied to a stable path in //eng:snk/ (via copy_file)
+# so that Arcade SDK version bumps don't invalidate the cache for every
+# signed assembly.  See eng/BUILD.bazel for the copy rules.
 
-MSFT_SNK = "@{}//:tools/snk/MSFT.snk".format(ARCADE_SDK_REPO)
-OPEN_SNK = "@{}//:tools/snk/Open.snk".format(ARCADE_SDK_REPO)
-ASPNETCORE_SNK = "@{}//:tools/snk/AspNetCore.snk".format(ARCADE_SDK_REPO)
-ECMA_SNK = "@{}//:tools/snk/ECMA.snk".format(ARCADE_SDK_REPO)
-SILVERLIGHT_SNK = "@{}//:tools/snk/SilverlightPlatformPublicKey.snk".format(ARCADE_SDK_REPO)
+MSFT_SNK = "//eng:snk/MSFT.snk"
+OPEN_SNK = "//eng:snk/Open.snk"
+ASPNETCORE_SNK = "//eng:snk/AspNetCore.snk"
+ECMA_SNK = "//eng:snk/ECMA.snk"
+SILVERLIGHT_SNK = "//eng:snk/SilverlightPlatformPublicKey.snk"
 
 # MIBC PGO optimization data files from NuGet (matched to target architecture).
 # MSBuild equivalent: eng/restore/optimizationData.targets selects the right

--- a/eng/BUILD.bazel
+++ b/eng/BUILD.bazel
@@ -1,6 +1,7 @@
 # Package for eng/ (enables subpackage references)
 
-load("//:defs.bzl", "XUNIT_CONSOLE_RUNNER_REPO")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("//:defs.bzl", "ARCADE_SDK_REPO", "XUNIT_CONSOLE_RUNNER_REPO")
 
 exports_files([
     "run_binary.sh.tpl",
@@ -8,6 +9,51 @@ exports_files([
     "run_library_test.sh.tpl",
     "testing/xunit/xunit.runner.json",
 ])
+
+# ── Stable-path copies of signing keys ───────────────────────────────
+# SNK files are sourced from the Arcade SDK NuGet package, whose repo
+# name contains a version string.  When the version bumps, the external
+# repo path changes, which changes Bazel action keys for every target
+# that uses a keyfile — even though the file content is identical.
+#
+# Copying to a fixed output path breaks that chain: the copy_file
+# action re-runs (instant), but downstream compilations see the same
+# path + same content digest → cache hit.
+
+copy_file(
+    name = "MSFT_snk",
+    src = "@{}//:tools/snk/MSFT.snk".format(ARCADE_SDK_REPO),
+    out = "snk/MSFT.snk",
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "Open_snk",
+    src = "@{}//:tools/snk/Open.snk".format(ARCADE_SDK_REPO),
+    out = "snk/Open.snk",
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "AspNetCore_snk",
+    src = "@{}//:tools/snk/AspNetCore.snk".format(ARCADE_SDK_REPO),
+    out = "snk/AspNetCore.snk",
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "ECMA_snk",
+    src = "@{}//:tools/snk/ECMA.snk".format(ARCADE_SDK_REPO),
+    out = "snk/ECMA.snk",
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "SilverlightPlatformPublicKey_snk",
+    src = "@{}//:tools/snk/SilverlightPlatformPublicKey.snk".format(ARCADE_SDK_REPO),
+    out = "snk/SilverlightPlatformPublicKey.snk",
+    visibility = ["//visibility:public"],
+)
 
 filegroup(
     name = "xunit_console_runner",


### PR DESCRIPTION
Bazel's disk cache action keys include input file paths (Merkle tree), not just content digests. When the Arcade SDK NuGet version bumps, the external repo path changes (e.g., @nuget...26102 -> @nuget...26110), which invalidates action keys for every signed assembly compilation -- even though the SNK file content is byte-identical.

Add copy_file rules in eng/BUILD.bazel that copy each SNK file from the versioned NuGet path to a fixed output path (eng/snk/*.snk). The copy action re-runs on version bumps (instant), but downstream compilations see the same path + same content digest -> cache hit.

This breaks the largest cache invalidation chain: Arcade SDK version bump -> ~785 assembly compilations -> Core_Root -> all JIT tests.