### PR TITLE
Fix Bazel CI cache key and save policy

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -50,9 +50,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/bazel-disk
-          key: bazel-${{ runner.os }}-${{ matrix.config }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelrc') }}-${{ github.sha }}
+          key: bazel-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}
           restore-keys: |
-            bazel-${{ runner.os }}-${{ matrix.config }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelrc') }}-
             bazel-${{ runner.os }}-${{ matrix.config }}-
 
       - name: Build
@@ -63,8 +62,8 @@ jobs:
         run: bazel test //... --config=${{ matrix.config }} ${{ matrix.libs_config && format('--config={0}', matrix.libs_config) || '' }} --disk_cache=~/.cache/bazel-disk --test_output=errors
 
       - name: Save Bazel cache
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/bazel-disk
-          key: bazel-${{ runner.os }}-${{ matrix.config }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelrc') }}-${{ github.sha }}
+          key: bazel-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}


### PR DESCRIPTION
## Problem

The `hashFiles(MODULE.bazel, MODULE.bazel.lock, .bazelrc)` segment in the CI cache key caused a new set of cache entries (~550MB each × 4 configs) every time those files changed. Since GitHub Actions caches are immutable, old entries under prior `hashFiles` prefixes were never replaced, filling the cache budget and causing saves to fail with:

```
Cache reservation failed: You have reached your configured budget, your cache is now read only
```

This left all subsequent runs (including PRs with zero Bazel graph changes) stuck restoring ancient stale caches and rebuilding thousands of actions.

## Fix

- **Remove `hashFiles` from the cache key.** Bazel disk caches are content-addressed internally, so a single stable prefix per `{os}-{config}` is sufficient. The `github.sha` suffix ensures immutability for each push, and the `restore-keys` prefix match finds the most recent cache.
- **Save cache on all non-PR events** (not just `push`), so scheduled runs also update the cache.
- **Manually purged 17 stale cache entries** (~9 GiB) to free up budget space.