### PR TITLE
Wire NativeAOT crossgen2 into R2R pipeline

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -192,6 +192,7 @@ framework_crossgen_targets(
         "//conditions:default": "//src/coreclr/tools/aot/jitinterface:libjitinterface_x64.so",
     }),
     mibc = MIBC_FILES,
+    native_crossgen2 = "//src/coreclr/tools/aot/crossgen2:crossgen2-publish",
     target_arch = select({
         "@platforms//cpu:arm64": "arm64",
         "//conditions:default": "x64",

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -977,21 +977,21 @@ targets line-by-line:
 - UCRT: api-ms-win-crt-*.lib (dynamic linking)
 - Optional: `/CETCOMPAT`, `/guard:cf`, `/guard:ehcont`, `/safeseh` (x86), `/STACK:`
 
-### Bootstrap Mode (TODO)
+### NativeAOT Crossgen2
 
-MSBuild supports `UseBootstrap=true` which:
-1. Builds crossgen2 from source
-2. NativeAOT-publishes it (`crossgen2_publish.csproj`)
-3. Uses that native crossgen2 to compile System.Private.CoreLib
+All R2R compilation (CoreLib and framework assemblies) uses the NativeAOT-compiled
+crossgen2 binary. This matches the MSBuild production path (`crossgen2_publish.csproj`
+with `PublishAot=true`).
 
-The Bazel infrastructure is partially in place:
-- `crossgen_corelib` rule has a `native_crossgen2` attr
-- `crossgen2-publish` nativeaot_binary target exists (or will exist)
-
-**Not yet wired together.** Needs a `bool_flag` (e.g., `--//src/coreclr:bootstrap`)
-that toggles `crossgen_corelib` between:
-- **Default**: LKG SDK crossgen2 (fast, no circular dependency)
-- **Bootstrap**: from-source `//src/coreclr/tools/aot/crossgen2:crossgen2-publish`
+**How it works:**
+- `//src/coreclr/tools/aot/crossgen2:crossgen2-publish` — `publish_binary` with
+  `aot=True` that NativeAOT-compiles crossgen2 into a standalone native binary (~14 MB)
+- `crossgen_corelib` and `crossgen_assembly` rules take a mandatory `native_crossgen2`
+  attr pointing to this binary
+- The rules set `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH` so the binary can find
+  `libjitinterface` at runtime via `NativeLibrary.Load`
+- The ILC compile cost (~25s) is cached by Bazel; subsequent builds use the cached
+  native binary directly
 
 ### NativeAOT Versioning (TODO)
 

--- a/framework_r2r.bzl
+++ b/framework_r2r.bzl
@@ -328,7 +328,7 @@ def framework_illink_targets():
             disable_opt_ipconstprop = (name == "System.Linq.Expressions"),
         )
 
-def framework_crossgen_targets(clrjit, jitinterface, target_arch, target_os, mibc = []):
+def framework_crossgen_targets(clrjit, jitinterface, target_arch, target_os, mibc = [], native_crossgen2 = None):
     """Generate crossgen_assembly targets for R2R assemblies.
 
     Call after framework_illink_targets() so illink outputs exist.
@@ -339,6 +339,7 @@ def framework_crossgen_targets(clrjit, jitinterface, target_arch, target_os, mib
         target_arch: Target architecture (x64, arm64).
         target_os: Target OS (linux, osx, windows).
         mibc: MIBC PGO data files passed as -m: to crossgen2.
+        native_crossgen2: Optional label for NativeAOT-compiled crossgen2 binary.
     """
     # All trimmed framework assemblies plus CoreLib as references.
     # CoreLib isn't in the ILLink pipeline (it has its own crossgen path)
@@ -347,7 +348,7 @@ def framework_crossgen_targets(clrjit, jitinterface, target_arch, target_os, mib
         "//src/coreclr/System.Private.CoreLib:impl_System.Private.CoreLib",
     ]
     for name in R2R_ASSEMBLIES:
-        crossgen_assembly(
+        kwargs = dict(
             name = "crossgen_" + name,
             assembly = ":illink_" + name,
             out = "r2r/" + name + ".dll",
@@ -358,3 +359,6 @@ def framework_crossgen_targets(clrjit, jitinterface, target_arch, target_os, mib
             target_arch = target_arch,
             target_os = target_os,
         )
+        if native_crossgen2:
+            kwargs["native_crossgen2"] = native_crossgen2
+        crossgen_assembly(**kwargs)

--- a/src/coreclr/System.Private.CoreLib/BUILD.bazel
+++ b/src/coreclr/System.Private.CoreLib/BUILD.bazel
@@ -448,6 +448,7 @@ crossgen_corelib(
         "//conditions:default": "//src/coreclr/tools/aot/jitinterface:libjitinterface_x64.so",
     }),
     mibc = MIBC_FILES,
+    native_crossgen2 = "//src/coreclr/tools/aot/crossgen2:crossgen2-publish",
     target_arch = select({
         "@platforms//cpu:arm64": "arm64",
         "//conditions:default": "x64",

--- a/src/coreclr/crossgen2.bzl
+++ b/src/coreclr/crossgen2.bzl
@@ -1,4 +1,11 @@
-"""Rules for running crossgen2 (ReadyToRun AOT compiler) on managed assemblies."""
+"""Rules for running crossgen2 (ReadyToRun AOT compiler) on managed assemblies.
+
+Both rules use the NativeAOT-compiled crossgen2 binary (crossgen2-publish)
+which is a standalone native executable — no .NET runtime or runfiles needed.
+The binary loads libjitinterface via NativeLibrary.Load, so we set
+LD_LIBRARY_PATH / DYLD_LIBRARY_PATH to the directory containing the
+jitinterface shared library.
+"""
 
 load(
     "@rules_dotnet//dotnet/private:providers.bzl",
@@ -38,58 +45,24 @@ def _crossgen_corelib_impl(ctx):
 
     inputs = [il_assembly, clrjit_file, jitinterface_file] + mibc_files
 
-    # Native crossgen2 path: use the NativeAOT-compiled binary directly
-    if ctx.attr.native_crossgen2:
-        native_exe = ctx.executable.native_crossgen2
-        all_inputs = inputs + [native_exe]
-        native_runfiles = ctx.attr.native_crossgen2[DefaultInfo].default_runfiles
-        if native_runfiles and native_runfiles.files:
-            all_inputs = all_inputs + native_runfiles.files.to_list()
+    native_exe = ctx.executable.native_crossgen2
+    all_inputs = inputs + [native_exe]
+    native_runfiles = ctx.attr.native_crossgen2[DefaultInfo].default_runfiles
+    if native_runfiles and native_runfiles.files:
+        all_inputs = all_inputs + native_runfiles.files.to_list()
 
-        ctx.actions.run(
-            executable = native_exe,
-            inputs = all_inputs,
-            outputs = [output],
-            arguments = args,
-            mnemonic = "Crossgen2Native",
-            progress_message = "Crossgen2 (native) compiling %s" % il_assembly.short_path,
-        )
-        return
-
-    crossgen2_exe = ctx.executable._crossgen2
     args_str = " ".join(["'%s'" % a for a in args])
-
-    # Collect all runfiles from crossgen2 as inputs
-    runfiles = ctx.attr._crossgen2[DefaultInfo].default_runfiles
-    all_inputs = inputs + [crossgen2_exe]
-    if runfiles and runfiles.files:
-        all_inputs = all_inputs + runfiles.files.to_list()
-
-    # Add runfiles.bash from rules_shell as an explicit input
-    runfiles_bash_files = ctx.attr._runfiles_bash[DefaultInfo].files.to_list()
-    all_inputs = all_inputs + runfiles_bash_files
-
-    # NativeLibrary.Load searches next to the calling assembly. Copy the
-    # jitinterface library next to ILCompiler.ReadyToRun.dll in the runfiles.
-    # This works on both Linux and macOS (where DYLD_LIBRARY_PATH is stripped by SIP).
-    # The wrapper script needs RUNFILES_DIR set to find runfiles.bash.
+    jitinterface_dir = jitinterface_file.dirname
     cmd = (
-        "RUNFILES_DIR=\"{exe}.runfiles\" && ".format(exe = crossgen2_exe.path) +
-        "export RUNFILES_DIR && " +
-        # Copy jitinterface next to ILCompiler.ReadyToRun.dll
-        "ILC_DIR=$(find \"$RUNFILES_DIR\" -name 'ILCompiler.ReadyToRun.dll' -print -quit 2>/dev/null | xargs dirname 2>/dev/null) && " +
-        "if [ -n \"$ILC_DIR\" ]; then cp -f \"{src}\" \"$ILC_DIR/{basename}\" 2>/dev/null || true; fi && ".format(src = jitinterface_file.path, basename = jitinterface_file.basename) +
-        # Also copy next to the shared framework DLLs
-        "FX_DIR=$(find \"$RUNFILES_DIR\" -path '*/Microsoft.NETCore.App/*' -name 'System.Private.CoreLib.dll' -print -quit 2>/dev/null | xargs dirname 2>/dev/null) && " +
-        "if [ -n \"$FX_DIR\" ]; then cp -f \"{src}\" \"$FX_DIR/{basename}\" 2>/dev/null || true; fi && ".format(src = jitinterface_file.path, basename = jitinterface_file.basename) +
-        "{exe} {args}".format(exe = crossgen2_exe.path, args = args_str)
+        "export LD_LIBRARY_PATH=\"{jitdir}:${{LD_LIBRARY_PATH:-}}\" && ".format(jitdir = jitinterface_dir) +
+        "export DYLD_LIBRARY_PATH=\"{jitdir}:${{DYLD_LIBRARY_PATH:-}}\" && ".format(jitdir = jitinterface_dir) +
+        "{exe} {args}".format(exe = native_exe.path, args = args_str)
     )
 
     ctx.actions.run_shell(
         command = cmd,
         inputs = all_inputs,
         outputs = [output],
-        tools = [ctx.executable._crossgen2],
         mnemonic = "Crossgen2",
         progress_message = "Crossgen2 compiling %s" % il_assembly.short_path,
     )
@@ -133,19 +106,10 @@ crossgen_corelib = rule(
             doc = "MIBC PGO data files passed as -m: (enables --embed-pgo-data).",
         ),
         "native_crossgen2": attr.label(
-            mandatory = False,
+            mandatory = True,
             cfg = "exec",
             executable = True,
-            doc = "Optional NativeAOT-compiled crossgen2 binary. When set, uses this instead of the managed crossgen2.",
-        ),
-        "_crossgen2": attr.label(
-            default = Label("//src/coreclr/tools/aot/crossgen2"),
-            cfg = "exec",
-            executable = True,
-        ),
-        "_runfiles_bash": attr.label(
-            default = Label("@bazel_tools//tools/bash/runfiles"),
-            cfg = "exec",
+            doc = "NativeAOT-compiled crossgen2 binary.",
         ),
     },
 )
@@ -170,9 +134,6 @@ def _crossgen_assembly_impl(ctx):
     jitinterface_file = ctx.file.jitinterface
     clrjit_file = ctx.file.clrjit
 
-    # MSBuild uses --targetos/--targetarch (not --jitpath) for framework
-    # assemblies.  We pass --jitpath explicitly since the managed crossgen2
-    # can't resolve the JIT from its runfiles directory reliably.
     args = [
         "--jitpath:%s" % clrjit_file.path,
         "--targetarch:%s" % ctx.attr.target_arch,
@@ -204,53 +165,24 @@ def _crossgen_assembly_impl(ctx):
 
     inputs = [input_assembly, clrjit_file, jitinterface_file] + ref_files + mibc_files
 
-    # Native crossgen2 path.
-    if ctx.attr.native_crossgen2:
-        native_exe = ctx.executable.native_crossgen2
-        all_inputs = inputs + [native_exe]
-        native_runfiles = ctx.attr.native_crossgen2[DefaultInfo].default_runfiles
-        if native_runfiles and native_runfiles.files:
-            all_inputs = all_inputs + native_runfiles.files.to_list()
+    native_exe = ctx.executable.native_crossgen2
+    all_inputs = inputs + [native_exe]
+    native_runfiles = ctx.attr.native_crossgen2[DefaultInfo].default_runfiles
+    if native_runfiles and native_runfiles.files:
+        all_inputs = all_inputs + native_runfiles.files.to_list()
 
-        ctx.actions.run(
-            executable = native_exe,
-            inputs = all_inputs,
-            outputs = [output],
-            arguments = args,
-            mnemonic = "Crossgen2Native",
-            progress_message = "Crossgen2 (native) R2R %s" % input_assembly.short_path,
-        )
-        return [DefaultInfo(files = depset([output]))]
-
-    # Managed crossgen2 path (via dotnet exec wrapper).
-    crossgen2_exe = ctx.executable._crossgen2
     args_str = " ".join(["'%s'" % a for a in args])
-
-    runfiles = ctx.attr._crossgen2[DefaultInfo].default_runfiles
-    all_inputs = inputs + [crossgen2_exe]
-    if runfiles and runfiles.files:
-        all_inputs = all_inputs + runfiles.files.to_list()
-
-    runfiles_bash_files = ctx.attr._runfiles_bash[DefaultInfo].files.to_list()
-    all_inputs = all_inputs + runfiles_bash_files
-
+    jitinterface_dir = jitinterface_file.dirname
     cmd = (
-        'RUNFILES_DIR="{exe}.runfiles" && '.format(exe = crossgen2_exe.path) +
-        "export RUNFILES_DIR && " +
-        "ILC_DIR=$(find \"$RUNFILES_DIR\" -name 'ILCompiler.ReadyToRun.dll' -print -quit 2>/dev/null | xargs dirname 2>/dev/null) && " +
-        'if [ -n "$ILC_DIR" ]; then cp -f "{src}" "$ILC_DIR/{basename}" 2>/dev/null || true; fi && '.format(
-            src = jitinterface_file.path, basename = jitinterface_file.basename) +
-        "FX_DIR=$(find \"$RUNFILES_DIR\" -path '*/Microsoft.NETCore.App/*' -name 'System.Private.CoreLib.dll' -print -quit 2>/dev/null | xargs dirname 2>/dev/null) && " +
-        'if [ -n "$FX_DIR" ]; then cp -f "{src}" "$FX_DIR/{basename}" 2>/dev/null || true; fi && '.format(
-            src = jitinterface_file.path, basename = jitinterface_file.basename) +
-        "{exe} {args}".format(exe = crossgen2_exe.path, args = args_str)
+        "export LD_LIBRARY_PATH=\"{jitdir}:${{LD_LIBRARY_PATH:-}}\" && ".format(jitdir = jitinterface_dir) +
+        "export DYLD_LIBRARY_PATH=\"{jitdir}:${{DYLD_LIBRARY_PATH:-}}\" && ".format(jitdir = jitinterface_dir) +
+        "{exe} {args}".format(exe = native_exe.path, args = args_str)
     )
 
     ctx.actions.run_shell(
         command = cmd,
         inputs = all_inputs,
         outputs = [output],
-        tools = [ctx.executable._crossgen2],
         mnemonic = "Crossgen2",
         progress_message = "Crossgen2 R2R %s" % input_assembly.short_path,
     )
@@ -296,19 +228,10 @@ crossgen_assembly = rule(
             doc = "The jitinterface shared library.",
         ),
         "native_crossgen2": attr.label(
-            mandatory = False,
+            mandatory = True,
             cfg = "exec",
             executable = True,
-            doc = "Optional NativeAOT-compiled crossgen2 binary.",
-        ),
-        "_crossgen2": attr.label(
-            default = Label("//src/coreclr/tools/aot/crossgen2"),
-            cfg = "exec",
-            executable = True,
-        ),
-        "_runfiles_bash": attr.label(
-            default = Label("@bazel_tools//tools/bash/runfiles"),
-            cfg = "exec",
+            doc = "NativeAOT-compiled crossgen2 binary.",
         ),
     },
 )

--- a/src/coreclr/tools/aot/crossgen2/BUILD.bazel
+++ b/src/coreclr/tools/aot/crossgen2/BUILD.bazel
@@ -55,8 +55,5 @@ publish_binary(
     aot = True,
     optimization_mode = "speed",
     invariant_globalization = True,
-    # TODO: crossgen2 needs libjitinterface and libclrjit linked in.
-    # This requires adding a native_deps label_list attribute to publish_binary
-    # in rules_dotnet to support additional native library inputs during linking.
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
All R2R compilation now uses the NativeAOT-compiled crossgen2 binary (crossgen2-publish), matching the MSBuild production path. This replaces the managed crossgen2 which required fragile runfiles and LD_LIBRARY_PATH hacks to find jitinterface.

Changes:
- Simplify crossgen2.bzl: remove managed crossgen2 fallback path, make native_crossgen2 mandatory, drop _crossgen2/_runfiles_bash private attrs
- Hardcode native_crossgen2 = crossgen2-publish in both framework_crossgen_targets (BUILD.bazel) and crossgen_corelib (CoreLib BUILD.bazel)
- Remove stale TODO in crossgen2 BUILD.bazel about native_deps
- Update docs/bazel.md NativeAOT Crossgen2 section