### PR TITLE
Split GC headers into public/private for fine-grained native build caching

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -544,7 +544,8 @@ The main CLR runtime engine. Large C++ codebase, 86 CMakeLists.txt files.
   - [x] `nativeresourcestring` static lib (resourcestring.cpp)
 
 ### 4.4 GC — ✅ DONE (linux-x64)
-- [x] `src/coreclr/gc/BUILD.bazel` — `gc_headers` (headers + inlines + defs + env/ + vxsort/ + unix/)
+- [x] `src/coreclr/gc/BUILD.bazel` — `gc_headers` (public headers + inlines + defs + env/ + vxsort/ + unix/)
+- [x] `gc_internal_headers` — private GC headers (gcpriv.h, gcimpl.h, handletablepriv.h), separated for cache efficiency
 - [x] `gc_pal` cc_library (OBJECT) — Unix PAL (gcenv.unix.cpp, numasupport.cpp, events.cpp, cgroup.cpp)
 - [x] `gc_vxsort` cc_library (OBJECT) — Vectorized sorting (AMD64 AVX2/AVX512 sources with `-mavx2`)
 - [x] Data descriptor stubs (gc_dll_wks_descriptor, gc_dll_svr_descriptor, gcexp_dll_wks_descriptor, gcexp_dll_svr_descriptor)
@@ -559,9 +560,11 @@ The main CLR runtime engine. Large C++ codebase, 86 CMakeLists.txt files.
 ### 4.6 VM (execution engine) — ✅ DONE (linux-x64)
 - [x] `src/coreclr/vm/BUILD.bazel` — `vm_headers` (headers + hpp + inlines + amd64/ + i386/)
 - [x] `cee_wks_asm` cc_library (23 .S assembly files, separate target without PCH)
-- [x] `cee_wks_core` cc_library (~220 .cpp VM core sources)
+- [x] `cee_wks_gc` cc_library (17 GC .cpp sources, uses `implementation_deps` for private GC headers)
+- [x] `cee_wks_core` cc_library (~220 .cpp VM core sources, depends on `cee_wks_gc`)
 - [x] `cee_wks` cc_library (ceemain.cpp, codeman.cpp, peimagelayout.cpp)
-- [x] `cee_dac` cc_library (~100 sources — DAC variant of the VM)
+- [x] `cee_dac_gc` cc_library (4 GC handle table .cpp sources, DAC variant with `implementation_deps`)
+- [x] `cee_dac` cc_library (~100 sources — DAC variant of the VM, depends on `cee_dac_gc`)
 - [x] `src/coreclr/vm/eventing/BUILD.bazel`
   - [x] `eventing_headers` — pre-generated event headers for linux-glibc-x64
   - [x] `eventpipe_gen_srcs` — pre-generated eventpipe C++ sources (5 files)

--- a/src/coreclr/gc/BUILD.bazel
+++ b/src/coreclr/gc/BUILD.bazel
@@ -10,6 +10,16 @@ exports_files(glob(["*.cpp", "unix/*.cpp", "unix/bazel/**/*.h", "vxsort/*.cpp", 
 
 # --- Headers ---
 
+# Private GC headers only needed by GC implementation sources (gc.cpp, gcee.cpp,
+# handletable*.cpp). Separated so that changes to these large headers (gcpriv.h
+# alone is ~7k lines) don't invalidate the ~220 VM .cpp files that never include
+# them.
+_GC_INTERNAL_HDRS = [
+    "gcpriv.h",
+    "gcimpl.h",
+    "handletablepriv.h",
+]
+
 cc_library(
     name = "gc_headers",
     hdrs = glob(
@@ -23,8 +33,17 @@ cc_library(
             "vxsort/smallsort/*.h",
             "unix/*.h",
         ],
+        exclude = _GC_INTERNAL_HDRS,
         allow_empty = True,
     ),
+)
+
+# Internal GC headers — only for targets that compile GC implementation sources.
+# Use via implementation_deps to prevent propagation to downstream consumers.
+cc_library(
+    name = "gc_internal_headers",
+    hdrs = _GC_INTERNAL_HDRS,
+    deps = [":gc_headers"],
 )
 
 # --- Standalone GC defines (shared by all GC compiled targets) ---
@@ -263,6 +282,7 @@ cc_library(
     alwayslink = True,
     deps = [
         ":gc_headers",
+        ":gc_internal_headers",
         ":gc_pal",
         ":gc_vxsort",
         ":gc_dll_wks_descriptor",
@@ -299,6 +319,7 @@ cc_library(
     alwayslink = True,
     deps = [
         ":gc_headers",
+        ":gc_internal_headers",
         ":gc_pal",
         ":gc_vxsort",
         ":gcexp_dll_wks_descriptor",

--- a/src/coreclr/nativeaot/BUILD.bazel
+++ b/src/coreclr/nativeaot/BUILD.bazel
@@ -257,12 +257,10 @@ _SERVER_GC_SRCS = [
 
 # Server GC textual headers already included via _GC_TEXTUAL_HDRS
 
-# All COMMON sources combined
+# All COMMON sources combined (excluding GC — GC is in separate library targets)
 _ALL_COMMON = (
     _NATIVEAOT_RUNTIME_SRCS +
     _CORECLR_RUNTIME_SRCS +
-    _GC_SRCS +
-    _GC_UNIX_SRCS +
     _UNIX_RUNTIME_SRCS
 )
 
@@ -390,6 +388,49 @@ cc_library(
 # generation is ported to Bazel.
 
 # ---------------------------------------------------------------------------
+# GC static libraries (compiled with NativeAOT defines)
+# ---------------------------------------------------------------------------
+# GC sources are compiled as separate libraries so that private GC headers
+# (gcpriv.h, gcimpl.h, handletablepriv.h) don't propagate to the ~100
+# NativeAOT runtime sources via implementation_deps.
+
+cc_library(
+    name = "nativeaot_gc_wks",
+    srcs = _GC_SRCS + _GC_UNIX_SRCS + _CORECLR_INC_FILES,
+    textual_hdrs = _GC_TEXTUAL_HDRS,
+    copts = NATIVEAOT_COPTS + CLR_CONFIG_COPTS,
+    includes = _GC_UNIX_INCLUDES,
+    defines = NATIVEAOT_DEFINES,
+    local_defines = CLR_BASE_CONFIG_DEFINES,
+    alwayslink = True,
+    linkstatic = True,
+    implementation_deps = [
+        "//src/coreclr/gc:gc_internal_headers",
+    ],
+    deps = _RUNTIME_DEPS + [
+        ":nativeaot_generated_headers",
+    ],
+)
+
+cc_library(
+    name = "nativeaot_gc_svr",
+    srcs = _GC_SRCS + _GC_UNIX_SRCS + _SERVER_GC_SRCS + _CORECLR_INC_FILES,
+    textual_hdrs = _GC_TEXTUAL_HDRS,
+    copts = NATIVEAOT_COPTS + CLR_CONFIG_COPTS,
+    includes = _GC_UNIX_INCLUDES,
+    defines = NATIVEAOT_DEFINES + ["FEATURE_SVR_GC"],
+    local_defines = CLR_BASE_CONFIG_DEFINES,
+    alwayslink = True,
+    linkstatic = True,
+    implementation_deps = [
+        "//src/coreclr/gc:gc_internal_headers",
+    ],
+    deps = _RUNTIME_DEPS + [
+        ":nativeaot_generated_headers",
+    ],
+)
+
+# ---------------------------------------------------------------------------
 # Runtime.WorkstationGC
 # ---------------------------------------------------------------------------
 
@@ -397,7 +438,7 @@ cc_library(
     name = "nativeaot_runtime_wks",
     srcs = _ALL_COMMON + _ALL_FULL + _ALL_ASM + _ASM_INCLUDES + _GENERATED_SRCS + _CORECLR_INC_FILES,
     hdrs = _RUNTIME_HDRS,
-    textual_hdrs = _GC_TEXTUAL_HDRS + _TEXTUAL_CPP_INCLUDES,
+    textual_hdrs = _TEXTUAL_CPP_INCLUDES,
     copts = NATIVEAOT_COPTS + CLR_CONFIG_COPTS,
     includes = _GC_UNIX_INCLUDES + _EVENTING_INCLUDES,
     defines = NATIVEAOT_DEFINES,
@@ -405,6 +446,7 @@ cc_library(
     linkstatic = True,
     deps = _RUNTIME_DEPS + [
         ":eventpipe_disabled",
+        ":nativeaot_gc_wks",
         ":nativeaot_generated_headers",
     ],
 )
@@ -415,9 +457,9 @@ cc_library(
 
 cc_library(
     name = "nativeaot_runtime_svr",
-    srcs = _ALL_COMMON + _ALL_FULL + _ALL_ASM + _ASM_INCLUDES + _SERVER_GC_SRCS + _GENERATED_SRCS + _CORECLR_INC_FILES,
+    srcs = _ALL_COMMON + _ALL_FULL + _ALL_ASM + _ASM_INCLUDES + _GENERATED_SRCS + _CORECLR_INC_FILES,
     hdrs = _RUNTIME_HDRS,
-    textual_hdrs = _GC_TEXTUAL_HDRS + _TEXTUAL_CPP_INCLUDES,
+    textual_hdrs = _TEXTUAL_CPP_INCLUDES,
     copts = NATIVEAOT_COPTS + CLR_CONFIG_COPTS,
     includes = _GC_UNIX_INCLUDES + _EVENTING_INCLUDES,
     defines = NATIVEAOT_DEFINES + ["FEATURE_SVR_GC"],
@@ -425,6 +467,7 @@ cc_library(
     linkstatic = True,
     deps = _RUNTIME_DEPS + [
         ":eventpipe_disabled",
+        ":nativeaot_gc_svr",
         ":nativeaot_generated_headers",
     ],
 )

--- a/src/coreclr/vm/BUILD.bazel
+++ b/src/coreclr/vm/BUILD.bazel
@@ -118,8 +118,67 @@ cc_library(
     ],
 )
 
+# --- cee_wks_gc (GC sources compiled with VM defines) ---
+# Separated from cee_wks_core so that changes to GC-internal headers
+# (gcpriv.h, gcimpl.h, handletablepriv.h) only recompile these ~17 GC
+# files instead of all ~220 VM files. Uses implementation_deps to
+# prevent private GC headers from propagating to VM consumers.
+cc_library(
+    name = "cee_wks_gc",
+    srcs = [
+        "//src/coreclr/gc:gcbridge.cpp",
+        "//src/coreclr/gc:gccommon.cpp",
+        "//src/coreclr/gc:gcconfig.cpp",
+        "//src/coreclr/gc:gceesvr.cpp",
+        "//src/coreclr/gc:gceewks.cpp",
+        "//src/coreclr/gc:gceventstatus.cpp",
+        "//src/coreclr/gc:gchandletable.cpp",
+        "//src/coreclr/gc:gcload.cpp",
+        "//src/coreclr/gc:gcscan.cpp",
+        "//src/coreclr/gc:gcsvr.cpp",
+        "//src/coreclr/gc:gcwks.cpp",
+        "//src/coreclr/gc:handletable.cpp",
+        "//src/coreclr/gc:handletablecache.cpp",
+        "//src/coreclr/gc:handletablecore.cpp",
+        "//src/coreclr/gc:handletablescan.cpp",
+        "//src/coreclr/gc:objecthandle.cpp",
+        "//src/coreclr/gc:softwarewritewatch.cpp",
+    ],
+    textual_hdrs = [
+        "//src/coreclr/gc:gc.cpp",
+        "//src/coreclr/gc:gcee.cpp",
+    ],
+    copts = _VM_COPTS + select({
+        "@platforms//cpu:arm64": [],
+        "//conditions:default": ["-mcx16"],
+    }),
+    includes = _VM_INCLUDES,
+    local_defines = CLR_CONFIG_DEFINES + select({
+        "//:clr_debug": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//:clr_checked": ["FEATURE_CACHED_INTERFACE_DISPATCH"],
+        "//conditions:default": [],
+    }),
+    defines = _VM_DEFINES + ["GC_DESCRIPTOR"] + select({
+        "//:debug_mode": ["WRITE_BARRIER_CHECK"],
+        "//conditions:default": [],
+    }),
+    alwayslink = True,
+    linkstatic = True,
+    implementation_deps = [
+        "//src/coreclr/gc:gc_internal_headers",
+    ],
+    deps = [
+        "//src/coreclr/gc:gc_headers",
+        "//src/coreclr/inc:coreclr_inc",
+        "//src/coreclr/runtime:runtime_headers",
+        "//src/coreclr/vm/eventing:eventing_headers",
+        "//src/native/eventpipe:eventpipe-headers",
+    ],
+)
+
 # --- cee_wks_core (VM core, workstation) ---
 # The main VM OBJECT library, containing ~220 .cpp files.
+# GC sources are in the separate cee_wks_gc target above.
 cc_library(
     name = "cee_wks_core",
     srcs = [
@@ -342,31 +401,10 @@ cc_library(
             "amd64/profiler.cpp",
             "amd64/stublinkeramd64.cpp",
         ],
-    }) + [
-        # GC sources (integrated into VM)
-        "//src/coreclr/gc:gcbridge.cpp",
-        "//src/coreclr/gc:gccommon.cpp",
-        "//src/coreclr/gc:gcconfig.cpp",
-        "//src/coreclr/gc:gceesvr.cpp",
-        "//src/coreclr/gc:gceewks.cpp",
-        "//src/coreclr/gc:gceventstatus.cpp",
-        "//src/coreclr/gc:gchandletable.cpp",
-        "//src/coreclr/gc:gcload.cpp",
-        "//src/coreclr/gc:gcscan.cpp",
-        "//src/coreclr/gc:gcsvr.cpp",
-        "//src/coreclr/gc:gcwks.cpp",
-        "//src/coreclr/gc:handletable.cpp",
-        "//src/coreclr/gc:handletablecache.cpp",
-        "//src/coreclr/gc:handletablecore.cpp",
-        "//src/coreclr/gc:handletablescan.cpp",
-        "//src/coreclr/gc:objecthandle.cpp",
-        "//src/coreclr/gc:softwarewritewatch.cpp",
-    ],
+    }),
     textual_hdrs = [
         "yieldprocessornormalizedshared.cpp",
         "i386/stublinkerx86.cpp",
-        "//src/coreclr/gc:gc.cpp",
-        "//src/coreclr/gc:gcee.cpp",
         "//src/coreclr/System.Private.CoreLib:src/System/Runtime/ExceptionServices/AsmOffsets.cs",
     ],
     copts = _VM_COPTS + select({
@@ -387,6 +425,7 @@ cc_library(
     linkstatic = True,
     deps = [
         ":cee_wks_asm",
+        ":cee_wks_gc",
         "//src/coreclr/classlibnative:classlibnative_headers",
         "//src/coreclr/gc:gc_headers",
         "//src/coreclr/inc:coreclr_inc",
@@ -447,6 +486,36 @@ _VM_DAC_DEFINES = CORECLR_DAC_DEFINES + [
     "FEATURE_HW_INTRINSICS",
     "FEATURE_MASKED_HW_INTRINSICS",
 ]
+
+# --- cee_dac_gc (GC handle table sources compiled with DAC defines) ---
+# Same cache-isolation pattern as cee_wks_gc: private GC headers don't
+# propagate to the ~90 DAC VM source files.
+cc_library(
+    name = "cee_dac_gc",
+    srcs = [
+        "//src/coreclr/gc:handletable.cpp",
+        "//src/coreclr/gc:handletablecore.cpp",
+        "//src/coreclr/gc:handletablescan.cpp",
+        "//src/coreclr/gc:objecthandle.cpp",
+    ],
+    copts = _VM_COPTS,
+    includes = _VM_INCLUDES + [
+        "../interop/inc",
+    ],
+    local_defines = CLR_CONFIG_DEFINES,
+    defines = _VM_DAC_DEFINES,
+    linkstatic = True,
+    implementation_deps = [
+        "//src/coreclr/gc:gc_internal_headers",
+    ],
+    deps = [
+        "//src/coreclr/gc:gc_headers",
+        "//src/coreclr/inc:coreclr_inc_dac",
+        "//src/coreclr/runtime:runtime_headers",
+        "//src/coreclr/vm/eventing:eventing_headers",
+        "//src/native/eventpipe:eventpipe-headers",
+    ],
+)
 
 cc_library(
     name = "cee_dac",
@@ -549,11 +618,6 @@ cc_library(
         # VM_SOURCES_DAC_ARCH
         "exceptionhandling.cpp",
         "peimagelayout.cpp",
-        # GC_SOURCES_DAC (handle table sources needed for linking)
-        "//src/coreclr/gc:handletable.cpp",
-        "//src/coreclr/gc:handletablecore.cpp",
-        "//src/coreclr/gc:handletablescan.cpp",
-        "//src/coreclr/gc:objecthandle.cpp",
     ] + select({
         "@platforms//cpu:arm64": [
             # VM_SOURCES_DAC_AND_WKS_ARCH (arm64)
@@ -578,6 +642,7 @@ cc_library(
     defines = _VM_DAC_DEFINES,
     linkstatic = True,
     deps = [
+        ":cee_dac_gc",
         "//src/coreclr/gc:gc_headers",
         "//src/coreclr/inc:coreclr_inc_dac",
         "//src/coreclr/interop:interop_headers",


### PR DESCRIPTION
## Problem

In Bazel, changing a header in a `cc_library`'s `hdrs` causes every consumer to rebuild. The `gc_headers` target was a monolithic glob of all GC headers — including `gcpriv.h` (6818 lines), `gcimpl.h`, and `handletablepriv.h` — even though these are only included by GC implementation `.cpp` files, never by VM sources.

A change to `gcpriv.h` triggered rebuilds of ~220 VM `.cpp` files + ~100 NativeAOT runtime sources, none of which include it. In CMake, the compiler's `-MD` dependency scanning avoids this naturally.

## Solution

Split GC headers into public and private targets, and compile GC sources behind library boundaries using `implementation_deps`:

### `gc/BUILD.bazel`
- **`gc_headers`**: Public GC headers (unchanged API surface)
- **`gc_internal_headers`**: Private headers (`gcpriv.h`, `gcimpl.h`, `handletablepriv.h`)

### `vm/BUILD.bazel`
- **`cee_wks_gc`**: New `cc_library` for 17 GC `.cpp` sources with `implementation_deps` for private headers
- **`cee_dac_gc`**: New `cc_library` for 4 DAC GC handle table sources

### `nativeaot/BUILD.bazel`
- **`nativeaot_gc_wks`** / **`nativeaot_gc_svr`**: GC sources compiled with NativeAOT defines, same `implementation_deps` pattern
- GC sources removed from `_ALL_COMMON` and runtime targets

## Result

A `gcpriv.h` change now recompiles only GC sources (~17 files) instead of all VM/NativeAOT runtime sources (~320 files), matching CMake's behavior.

## Testing

- All native targets build: `libcoreclr.so`, `libmscordaccore.so`, `libmscordbi.so`, `clrgc`, `clrgcexp`, NativeAOT wks/svr
- `bazel test //... --config=clr_release -c opt`: **5634 tests pass**, 0 failures, 5 pre-existing skips
- `bazel test //src/libraries/... //src/native/...`: **132 tests pass**, 0 failures