### PR TITLE
Tag all async tests as manual with runtime-async=on compiler feature

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -727,7 +727,9 @@ and System.Net.Quic (msquic native library + full Linux implementation).
   - plus smaller counts in Exceptions, nativeaot, profiler, tracing, ilasm, managed
 - [x] Pri1 test filtering: `--test_tag_filters=-pri1` in `.bazelrc` excludes expensive
   tests by default; run `bazel test //... --test_tag_filters=` to include them
-- [x] ~134 tests tagged `manual` (need native deps, multi-project builds, or sandbox-incompatible)
+- [x] ~150 tests tagged `manual` (need native deps, multi-project builds, sandbox-incompatible,
+  or runtime-async support not yet available); all 31 async tests are `manual` because the
+  `runtime-async=on` compiler feature they require is not yet supported by the Bazel-built runtime
 - [x] ~23 tests with `target_compatible_with = ["@platforms//os:windows"]` for Windows-only tests
 - [x] 117 library test suites (see §1 "What Works" for full list;
   includes 5 platform-constrained suites: Microsoft.Win32.Registry (Windows),

--- a/src/tests/async/byref-param/BUILD.bazel
+++ b/src/tests/async/byref-param/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "byref-param",
-    srcs = ["byref-param.cs"],
+    srcs = [
+        "byref-param.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/collectible-alc/BUILD.bazel
+++ b/src/tests/async/collectible-alc/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "collectible-alc",
-    srcs = ["collectible-alc.cs"],
+    srcs = [
+        "collectible-alc.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/execution-context/BUILD.bazel
+++ b/src/tests/async/execution-context/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "execution-context",
-    srcs = ["execution-context.cs"],
+    srcs = [
+        "execution-context.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/fibonacci-with-yields-struct-return/BUILD.bazel
+++ b/src/tests/async/fibonacci-with-yields-struct-return/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "fibonacci-with-yields-struct-return",
-    srcs = ["fibonacci-with-yields-struct-return.cs"],
+    srcs = [
+        "fibonacci-with-yields-struct-return.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/fibonacci-with-yields/BUILD.bazel
+++ b/src/tests/async/fibonacci-with-yields/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "fibonacci-with-yields",
-    srcs = ["fibonacci-with-yields.cs"],
+    srcs = [
+        "fibonacci-with-yields.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/fibonacci-without-yields-config-await/BUILD.bazel
+++ b/src/tests/async/fibonacci-without-yields-config-await/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "fibonacci-without-yields-config-await",
-    srcs = ["fibonacci-without-yields-config-await.cs"],
+    srcs = [
+        "fibonacci-without-yields-config-await.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/fibonacci-without-yields/BUILD.bazel
+++ b/src/tests/async/fibonacci-without-yields/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "fibonacci-without-yields",
-    srcs = ["fibonacci-without-yields.cs"],
+    srcs = [
+        "fibonacci-without-yields.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/inst-unbox-thunks/BUILD.bazel
+++ b/src/tests/async/inst-unbox-thunks/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "inst-unbox-thunks",
-    srcs = ["inst-unbox-thunks.cs"],
+    srcs = [
+        "inst-unbox-thunks.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/pgo/BUILD.bazel
+++ b/src/tests/async/pgo/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "pgo",
-    srcs = ["pgo.cs"],
+    srcs = [
+        "pgo.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/pinvoke/BUILD.bazel
+++ b/src/tests/async/pinvoke/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "pinvoke",
-    srcs = ["pinvoke.cs"],
+    srcs = [
+        "pinvoke.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/returns/BUILD.bazel
+++ b/src/tests/async/returns/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "returns",
-    srcs = ["returns.cs"],
+    srcs = [
+        "returns.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/small/BUILD.bazel
+++ b/src/tests/async/small/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "small",
-    srcs = ["small.cs"],
+    srcs = [
+        "small.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/strength-reduction/BUILD.bazel
+++ b/src/tests/async/strength-reduction/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "strength-reduction",
-    srcs = ["strength-reduction.cs"],
+    srcs = [
+        "strength-reduction.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/synchronization-context/BUILD.bazel
+++ b/src/tests/async/synchronization-context/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "synchronization-context",
-    srcs = ["synchronization-context.cs"],
+    srcs = [
+        "synchronization-context.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/valuetask/BUILD.bazel
+++ b/src/tests/async/valuetask/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "valuetask",
-    srcs = ["valuetask.cs"],
+    srcs = [
+        "valuetask.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )

--- a/src/tests/async/widening-tailcall/BUILD.bazel
+++ b/src/tests/async/widening-tailcall/BUILD.bazel
@@ -2,6 +2,11 @@ load("//src/tests:live_test.bzl", "coreclr_test")
 
 coreclr_test(
     name = "widening-tailcall",
-    srcs = ["widening-tailcall.cs"],
+    srcs = [
+        "widening-tailcall.cs",
+        "//src/tests/async:RuntimeAsyncMethodGenerationAttribute.cs",
+    ],
     optimize = True,
+    compiler_options = ["/features:runtime-async=on", "/nowarn:SYSLIB5007"],
+    tags = ["manual"],  # Requires runtime-async support not yet in Bazel runtime
 )


### PR DESCRIPTION
All tests under src/tests/async/ require the runtime-async=on C# compiler feature flag, which MSBuild applies via Directory.Build.props. The generator only tagged tests that explicitly reference RuntimeAsyncMethodGenerationAttribute, missing 16 tests (including synchronization-context) that depend on runtime-async behavior without using the attribute.

Without runtime-async=on, tests like synchronization-context fail intermittently because the standard async state machine doesn't implement the SyncContext save/restore semantics that the tests assert. The SyncContext is captured by TaskAwaiter at the await point, and a thread-pool race can cause the continuation to see the original SyncContext instead of null.

Fix: add compiler_options=['/features:runtime-async=on', '/nowarn:SYSLIB5007'], RuntimeAsyncMethodGenerationAttribute.cs source, and tags=['manual'] to all 16 async tests that were missing them. All async tests are now manual since the Bazel-built runtime doesn't support runtime-async yet.