### PR TITLE
Use GitHub App token for sync PR creation

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -56,10 +56,18 @@ jobs:
       - name: Install Paket
         run: dotnet tool install -g paket --add-source https://api.nuget.org/v3/index.json
 
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
       - name: Run sync
         id: run-sync
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PR_TOKEN: ${{ steps.app-token.outputs.token }}
         run: >-
           chmod +x src/tools/bazel/sync-upstream.sh src/tools/bazel/detect-upstream-changes.sh &&
           src/tools/bazel/sync-upstream.sh

--- a/src/tools/bazel/sync-upstream.sh
+++ b/src/tools/bazel/sync-upstream.sh
@@ -347,8 +347,10 @@ else
     full_body=$(printf '%s' "$header" && cat "$report_file")
     echo "$full_body" > "$report_file"
 
+    # Use GH_PR_TOKEN if available so the PR triggers pull_request workflows.
+    # PRs created with GITHUB_TOKEN don't fire events (GitHub security feature).
     # shellcheck disable=SC2086
-    pr_url=$(gh pr create \
+    pr_url=$(GH_TOKEN="${GH_PR_TOKEN:-$GH_TOKEN}" gh pr create \
         --repo "$REPO" \
         --base "$BASE_BRANCH" \
         --head "$branch" \


### PR DESCRIPTION
PRs created with `GITHUB_TOKEN` don't trigger `pull_request` workflows (GitHub security feature). This switches the sync workflow to use a GitHub App token via `actions/create-github-app-token` so that `bazel.yml` CI runs automatically on sync PRs.

**Changes:**
- Added a "Generate App token" step using `actions/create-github-app-token@v2`
- Pass the App token as `GH_PR_TOKEN` to `sync-upstream.sh`
- `gh pr create` uses `GH_PR_TOKEN` when available, falling back to `GH_TOKEN`

**Required secrets:** `SYNC_APP_ID`, `SYNC_APP_PRIVATE_KEY`